### PR TITLE
KTO-856: Simplify i18next language detection and switching

### DIFF
--- a/src/main/app/package.json
+++ b/src/main/app/package.json
@@ -10,7 +10,6 @@
     "axios": "^0.19.2",
     "clsx": "^1.1.0",
     "date-fns": "^2.14.0",
-    "i18next-browser-languagedetector": "^2.2.4",
     "i18next-http-backend": "^1.0.15",
     "jschannel": "1.0.2",
     "local-storage": "^2.0.0",

--- a/src/main/app/src/App.js
+++ b/src/main/app/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import KonfoStore from './stores/konfo-store';
@@ -66,6 +66,61 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const KoulutusHakuBar = () => (
+  <div style={{ margin: 'auto', paddingTop: '50px', maxWidth: '1600px' }}>
+    <ReactiveBorder>
+      <Hakupalkki />
+    </ReactiveBorder>
+  </div>
+);
+
+const TranslatedRoutes = ({ match }) => {
+  const { i18n } = useTranslation();
+  const selectedLanguage = match.params.lng;
+  useEffect(() => {
+    selectedLanguage &&
+      supportedLanguages.includes(selectedLanguage) &&
+      i18n.changeLanguage(selectedLanguage);
+  }, [i18n, selectedLanguage]);
+  return supportedLanguages.includes(selectedLanguage) ? (
+    <Switch>
+      <Route exact path="/:lng">
+        <Etusivu />
+      </Route>
+      <Route path="/:lng/sisaltohaku/">
+        <Sisaltohaku />
+      </Route>
+      <Route path="/:lng/haku/:keyword?">
+        <KoulutusHakuBar />
+        <Haku />
+      </Route>
+      <Route path="/:lng/koulutus/:oid">
+        <KoulutusHakuBar />
+        <Koulutus />
+      </Route>
+      <Route path="/:lng/oppilaitos/:oid">
+        <KoulutusHakuBar />
+        <Oppilaitos />
+      </Route>
+      <Route path="/:lng/toteutus/:oid">
+        <KoulutusHakuBar />
+        <Toteutus />
+      </Route>
+      <Route path="/:lng/sivu/:id">
+        <KoulutusHakuBar />
+        <SivuRouter />
+      </Route>
+      <Route path="/:lng/hakukohde/:hakukohdeOid/valintaperuste/:valintaperusteOid">
+        <KoulutusHakuBar />
+        <Valintaperusteet />
+      </Route>
+      <Route component={NotFound} />
+    </Switch>
+  ) : (
+    <Route component={NotFound} />
+  );
+};
+
 const App = () => {
   const classes = useStyles();
   const hakuStore = konfoStore.hakuStore;
@@ -86,59 +141,12 @@ const App = () => {
   const closeMenu = () => {
     setMenuVisible(false);
   };
-  const KoulutusHakuBar = () => (
-    <div style={{ margin: 'auto', paddingTop: '50px', maxWidth: '1600px' }}>
-      <ReactiveBorder>
-        <Hakupalkki />
-      </ReactiveBorder>
-    </div>
-  );
+
   const main = (
     <React.Fragment>
       <Switch>
         <Redirect exact from="/" to={`/${i18n.language}/`} />
-        <Route
-          path="/:lng"
-          component={({ match }) =>
-            supportedLanguages.includes(match.params.lng) ? (
-              <Switch>
-                <Route exact path="/:lng">
-                  <Etusivu />
-                </Route>
-                <Route path="/:lng/sisaltohaku/">
-                  <Sisaltohaku />
-                </Route>
-                <Route path="/:lng/haku/:keyword?">
-                  <KoulutusHakuBar />
-                  <Haku />
-                </Route>
-                <Route path="/:lng/koulutus/:oid">
-                  <KoulutusHakuBar />
-                  <Koulutus />
-                </Route>
-                <Route path="/:lng/oppilaitos/:oid">
-                  <KoulutusHakuBar />
-                  <Oppilaitos />
-                </Route>
-                <Route path="/:lng/toteutus/:oid">
-                  <KoulutusHakuBar />
-                  <Toteutus />
-                </Route>
-                <Route path="/:lng/sivu/:id">
-                  <KoulutusHakuBar />
-                  <SivuRouter />
-                </Route>
-                <Route path="/:lng/hakukohde/:hakukohdeOid/valintaperuste/:valintaperusteOid">
-                  <KoulutusHakuBar />
-                  <Valintaperusteet />
-                </Route>
-                <Route component={NotFound} />
-              </Switch>
-            ) : (
-              <Route component={NotFound} />
-            )
-          }
-        />
+        <Route path="/:lng" component={TranslatedRoutes} />
       </Switch>
       <Palvelut />
       <Footer />

--- a/src/main/app/src/components/common/LanguageDropDown.js
+++ b/src/main/app/src/components/common/LanguageDropDown.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   FormControl,
   Select,
@@ -12,7 +12,6 @@ import { colors } from '#/src/colors';
 import LanguageIcon from '@material-ui/icons/Language';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import { useLocation, useHistory } from 'react-router-dom';
-import { supportedLanguages, defaultLanguage } from '#/src/tools/i18n';
 
 const CustomInput = withStyles((theme) => ({
   input: {
@@ -32,16 +31,10 @@ const LanguageDropDown = () => {
   const { i18n, t } = useTranslation();
   const location = useLocation();
   const history = useHistory();
-  const [language, setLanguage] = useState(
-    supportedLanguages.includes(i18n.language) ? i18n.language : defaultLanguage
-  );
   const handleChange = (event) => {
     const newLanguage = event.target.value;
-    if (newLanguage !== language) {
-      setLanguage(newLanguage);
-      const newPath = location.pathname.replace(/\/(.*?)\//, `/${newLanguage}/`); // Replace first path index with new language selection
-      i18n.changeLanguage(newLanguage).then(history.push(newPath));
-    }
+    const newPath = location.pathname.replace(/\/(.*?)\//, `/${newLanguage}/`); // Replace first path index with new language selection
+    history.push(newPath);
   };
   return (
     <Box display="flex" flexDirection="column" alignItems="center">
@@ -55,7 +48,7 @@ const LanguageDropDown = () => {
             },
             getContentAnchorEl: null,
           }}
-          value={language}
+          value={i18n.language}
           onChange={handleChange}
           variant="standard"
           renderValue={(value) => value.toUpperCase()}

--- a/src/main/app/src/tools/i18n.js
+++ b/src/main/app/src/tools/i18n.js
@@ -1,17 +1,16 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import Backend from 'i18next-http-backend';
-import LanguageDetector from 'i18next-browser-languagedetector';
 
 export const supportedLanguages = ['fi', 'sv', 'en'];
 export const defaultLanguage = 'fi';
 
 i18n
   .use(Backend)
-  .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     fallbackLng: defaultLanguage,
+    lng: defaultLanguage,
     supportedLngs: supportedLanguages,
     debug: process.env.NODE_ENV === 'development',
     load: 'languageOnly',
@@ -26,10 +25,6 @@ i18n
       customHeaders: {
         'Caller-Id': '1.2.246.562.10.00000000001.konfoui',
       },
-    },
-    detection: {
-      order: ['path'],
-      lookupFromPathIndex: 1,
     },
   });
 


### PR DESCRIPTION
- Use a hook instead of LanguageDetector, which is overkill and doesn't seem to work when using history.push()
- Changing app language centralized via URL