### PR TITLE
KTO-1213: Poistettu imageContainer-tyylit oppilaitoksen teemakuvalta

### DIFF
--- a/src/main/app/src/components/oppilaitos/OppilaitosPage.js
+++ b/src/main/app/src/components/oppilaitos/OppilaitosPage.js
@@ -33,7 +33,6 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: '1600px',
   },
   title: { marginTop: 40 },
-  imageContainer: { maxWidth: '1600px', maxHeight: '400px' },
   alatText: {
     ...theme.typography.body1,
     fontSize: '1.25rem',
@@ -89,7 +88,7 @@ export const OppilaitosPage = (props) => {
                 {localize(entity)}
               </Typography>
             </Box>
-            <Box className={classes.imageContainer} mt={7.5}>
+            <Box mt={7.5}>
               <TeemakuvaImage
                 imgUrl={entity?.teemakuva}
                 altText={t('oppilaitos.oppilaitoksen-teemakuva')}


### PR DESCRIPTION
- Millään muullakaan teemakuvalla ei ole maxWidth ja maxHeight rajoitteita, eikä niistä tässä ole kuin harmia (teemakuva menee otsikon päälle)