### PR TITLE
OY-4384 Collapse ka-laskuri columns to rows before labels overlap

### DIFF
--- a/src/main/app/src/components/laskuri/KeskiarvoLaskuri.tsx
+++ b/src/main/app/src/components/laskuri/KeskiarvoLaskuri.tsx
@@ -127,8 +127,15 @@ export const KeskiarvoLaskuri = ({
       <Grid
         container
         justifyContent="space-evenly"
-        columns={{ xs: 1, sm: 1, md: embedded ? 10 : 3 }}>
-        <Grid item xs={1} sm={1} md={embedded ? 3 : 1} className={classes.inputContainer}>
+        columns={{ xs: 1, sm: 1, md: 1, lg: 1, xl: embedded ? 10 : 3 }}>
+        <Grid
+          item
+          xs={1}
+          sm={1}
+          md={1}
+          lg={1}
+          xl={embedded ? 3 : 1}
+          className={classes.inputContainer}>
           <InputLabel>
             <Typography sx={{ fontWeight: '600' }}>
               {t('pistelaskuri.ka-lukuaineet')}
@@ -157,7 +164,9 @@ export const KeskiarvoLaskuri = ({
           item
           xs={1}
           sm={1}
-          md={embedded ? 4 : 1}
+          md={1}
+          lg={1}
+          xl={embedded ? 4 : 1}
           sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
           <InputLabel>
             <Typography sx={{ fontWeight: '600' }}>
@@ -185,7 +194,14 @@ export const KeskiarvoLaskuri = ({
             </Typography>
           )}
         </Grid>
-        <Grid item xs={1} sm={1} md={embedded ? 3 : 1} className={classes.inputContainer}>
+        <Grid
+          item
+          xs={1}
+          sm={1}
+          md={1}
+          lg={1}
+          xl={embedded ? 3 : 1}
+          className={classes.inputContainer}>
           <InputLabel>
             <Typography sx={{ fontWeight: '600' }}>
               {t('pistelaskuri.ka-kaikki')}


### PR DESCRIPTION
This is a quick compromise, without the side menu open the laskuri collapses a tiny bit too late, without the menu open a tiny bit too early.

The rest of the responsive / media query adjustments are left as is.