### PR TITLE
Ok 335 amm pistegraafi

### DIFF
--- a/src/main/app/playwright/komoto-pistelaskuri.spec.ts
+++ b/src/main/app/playwright/komoto-pistelaskuri.spec.ts
@@ -19,6 +19,13 @@ test.describe('Pistelaskuri KOMOTO', () => {
     await expect(page.locator('#mui-component-select-hakukohde-select')).toHaveText(
       /^Lukion yleislinja/
     );
+    await expect(page.locator('.graafi__container__pistetyyppitext')).toHaveText(
+      /^sisäänpääsyn alin keskiarvo tai pistemäärä/
+    );
+    await expect(page.locator('.graafi__container__pistetyyppibox')).toHaveCSS(
+      'background-color',
+      'rgb(91, 202, 19)'
+    );
   });
 
   test('Shows keskiarvo dialog', async ({ page }) => {

--- a/src/main/app/playwright/komoto-pistelaskuri.spec.ts
+++ b/src/main/app/playwright/komoto-pistelaskuri.spec.ts
@@ -20,7 +20,7 @@ test.describe('Pistelaskuri KOMOTO', () => {
       /^Lukion yleislinja/
     );
     await expect(page.locator('.graafi__container__pistetyyppitext')).toHaveText(
-      /^sisäänpääsyn alin keskiarvo tai pistemäärä/
+      /^sisäänpääsyn alin keskiarvo/
     );
     await expect(page.locator('.graafi__container__pistetyyppibox')).toHaveCSS(
       'background-color',
@@ -109,5 +109,29 @@ test.describe('Pistelaskuri KOMOTO', () => {
     await expect(keskiarvoPalleroTulokset.nth(0)).toHaveText('8');
     await expect(keskiarvoPalleroTulokset.nth(1)).toHaveText('12');
     await expect(keskiarvoPalleroTulokset.nth(2)).toHaveText('10');
+  });
+});
+
+test.describe('Pistelaskuri KOMOTO for yhteispisteet', () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await setupCommonTest({ page, context, baseURL });
+    await mocksFromFile(page, 'komoto-pistelaskuri.mocks.json');
+    await page.goto('/konfo/fi/toteutus/1.2.246.562.17.00000000000000005701');
+  });
+
+  test('Pistelaskuri KOMOTO renders properly', async ({ page }) => {
+    await expect(page.locator('.PisteContainer__infobox')).toHaveText(
+      /^Edellisvuosien alin hyväksytty pistemäärä, jolla oppilaitokseen on päässyt opiskelemaan./
+    );
+    await expect(page.locator('#mui-component-select-hakukohde-select')).toHaveText(
+      /^Lukion yleislinja/
+    );
+    await expect(page.locator('.graafi__container__pistetyyppitext')).toHaveText(
+      'sisäänpääsyn alin pistemäärä (keskiarvo + pääsykoe ja/tai lisänäyttö)'
+    );
+    await expect(page.locator('.graafi__container__pistetyyppibox')).toHaveCSS(
+      'background-color',
+      'rgb(230, 8, 149)'
+    );
   });
 });

--- a/src/main/app/playwright/mocks/komoto-pistelaskuri.mocks.json
+++ b/src/main/app/playwright/mocks/komoto-pistelaskuri.mocks.json
@@ -543,6 +543,548 @@
   },
   {
     "method": "GET",
+    "url": "http://localhost:3005/konfo-backend/toteutus/1.2.246.562.17.00000000000000005701",
+    "response": {
+      "status": 200,
+      "body": {
+        "tila": "julkaistu",
+        "kuuluuOpintokokonaisuuksiin": null,
+        "liitetytOpintojaksot": [],
+        "hakuAuki": null,
+        "oppilaitokset": ["1.2.246.562.10.54943480589"],
+        "teemakuva": "https://konfo-files.opintopolku.fi/toteutus-teemakuva/1.2.246.562.17.00000000000000005700/58b1edb5-409d-40d4-8cb1-a83a4a58bf72.jpg",
+        "koulutukset": [
+          {
+            "koodiUri": "koulutus_309902#7",
+            "nimi": { "sv": "Gymnasiets lärokurs", "fi": "Lukion oppimäärä" }
+          }
+        ],
+        "tarjoajat": [
+          {
+            "paikkakunta": {
+              "koodiUri": "kunta_005",
+              "nimi": { "fi": "Alajärvi", "sv": "Alajärvi" }
+            },
+            "nimi": {
+              "fi": "Alajärven lukio",
+              "sv": "Alajärven lukio",
+              "en": "Alajärven lukio"
+            },
+            "oid": "1.2.246.562.10.54943480589"
+          }
+        ],
+        "esikatselu": true,
+        "modified": "2022-07-12T20:02:10",
+        "koulutusOid": "1.2.246.562.13.00000000000000001022",
+        "nimi": {
+          "fi": "Lukio, 61 opintopistettä",
+          "sv": "Gymnasium, 61 studiepoäng",
+          "en": "Lukio, 61 credits"
+        },
+        "muokkaaja": {
+          "oid": "1.2.246.562.24.98478395032",
+          "nimi": "Anonymisoitu Virkailija"
+        },
+        "oid": "1.2.246.562.17.00000000000000005700",
+        "kielivalinta": ["fi", "en"],
+        "haut": [
+          "1.2.246.562.29.00000000000000021303",
+          "1.2.246.562.29.00000000000000005368"
+        ],
+        "koulutustyyppiPath": "lk",
+        "timestamp": 1670511433940,
+        "organisaatiot": ["1.2.246.562.10.54943480589"],
+        "organisaatio": {
+          "paikkakunta": {
+            "koodiUri": "kunta_005",
+            "nimi": { "fi": "Alajärvi", "sv": "Alajärvi" }
+          },
+          "nimi": {
+            "fi": "Alajärven lukio",
+            "sv": "Alajärven lukio",
+            "en": "Alajärven lukio"
+          },
+          "oid": "1.2.246.562.10.54943480589"
+        },
+        "metadata": {
+          "erityisetKoulutustehtavat": [],
+          "painotukset": [],
+          "kuvaus": {
+            "en": "<p>Our school has a general curriculum option and and an eSports option called KOVA academy.</p>",
+            "fi": "<p>Lukiossa toimii yleislinja ja esports-linja KOVA-akatemia.</p><p>Hakeminen KOVA-akatemiaan:</p><p>· Täytä hakemus oppilaitokseen opintopolussa yhteishaussa ja</p><p>· Täytä erillishakemus osoitteessa <a href=\"http://www.kovaakatemia.fi/\" rel=\"noopener noreferrer\" target=\"_blank\">www.kovaakatemia.fi</a></p><p>Tutustu esport-opintoihin osoitteessa <a href=\"http://www.kovaakatemia.fi/\" rel=\"noopener noreferrer\" target=\"_blank\">www.kovaakatemia.fi</a></p>"
+          },
+          "diplomit": [
+            {
+              "koodi": {
+                "koodiUri": "moduulikoodistolops2021_kuld2#1",
+                "nimi": {
+                  "fi": "Kuvataiteen lukiodiplomi ",
+                  "sv": "Gymnasiediplom i bildkonst"
+                }
+              },
+              "linkki": {},
+              "linkinAltTeksti": {},
+              "sisallot": [
+                {
+                  "fi": "perustuvat lukiodiplomille asetettuihin tavoitteisiin sekä valittuun tehtävään, näkökulmaan ja toteutustapaan",
+                  "sv": "utgår från målen som ställts upp för gymnasiediplomet samt den uppgift, det perspektiv och arbetssätt som den studerande valt"
+                },
+                {
+                  "fi": "muodostuvat teoksesta sekä työskentelyprosessia, itsearviointia sekä kuvataiteen ja muun visuaalisen kulttuurin tuntemusta kuvaavasta portfoliosta.",
+                  "sv": "omfattar verket och arbetsprocessen, självvärdering och en portfölj som beskriver den studerandes kunnande om bildkonst och övrig visuell kultur"
+                }
+              ],
+              "tavoitteetKohde": {
+                "fi": "Moduulin tavoitteena on, että opiskelija",
+                "sv": "Målen för modulen är att den studerande ska"
+              },
+              "tavoitteet": [
+                {
+                  "fi": "antaa erityisen näytön lukioaikaisesta osaamisestaan ja harrastuneisuudestaan kuvataiteessa",
+                  "sv": "genom en särskild prestation visa prov på sitt intresse för bildkonst och de ämneskunskaper och färdigheter som den studerande har utvecklat under gymnasiestudierna"
+                },
+                {
+                  "fi": "osoittaa kuvataiteen ja muun visuaalisen kulttuurin osaamistaan tuottamalla, tulkitsemalla ja arvottamalla monipuolisesti kuvia",
+                  "sv": "visar sitt kunnande inom bildkonst och annan visuell kultur genom att producera, tolka och värdera olika bilder på ett mångsidigt sätt"
+                },
+                {
+                  "fi": "osaa kertoa ja välittää lukiodiplomille asettamansa tavoitteet ja lähtökohdat",
+                  "sv": "kunna redogöra för och förmedla de mål och utgångspunkter som hen ställt upp för gymnasiediplomet"
+                },
+                {
+                  "fi": "osaa tuottaa taiteellisen ja visuaalisen kokonaisuuden, jonka sisällön tuottamisen ja esittämisen tavat tukevat toisiaan",
+                  "sv": "kunna producera en konstnärlig och visuell helhet där arbetssätten och hur innehållet presenteras stödjer och kompletterar varandra"
+                },
+                {
+                  "fi": "osoittaa kuvataiteen ja muun visuaalisen kulttuurin tuntemusta",
+                  "sv": "visa sitt kunnande inom bildkonst och övrig visuell kultur"
+                },
+                {
+                  "fi": "osaa arvioida työskentelyprosessia ja teosta oman oppimisen näkökulmasta.",
+                  "sv": "kunna utvärdera arbetsprocessen och verket med utgångspunkt i sitt eget lärande."
+                }
+              ]
+            },
+            {
+              "koodi": {
+                "koodiUri": "moduulikoodistolops2021_kald3#1",
+                "nimi": { "fi": "Käsityön lukiodiplomi ", "sv": "Gymnasiediplom i slöjd" }
+              },
+              "linkki": {},
+              "linkinAltTeksti": {},
+              "sisallot": [
+                {
+                  "fi": "perustuvat valittuun tehtävään, ideaan ja suunnittelu- ja valmistusprosessiin sekä niiden itsearviointiin",
+                  "sv": "utgår från den valda uppgiften och idén, från planerings- och arbetsprocessen och från självvärderingen av dessa"
+                },
+                {
+                  "fi": "muodostuvat käsityötuotteesta tai käsityöteoksesta sekä sen suunnittelu- ja valmistusprosessia ja itsearviointia kuvaavasta portfoliosta.",
+                  "sv": "omfattar en slöjdprodukt eller ett verk och en portfölj som beskriver planerings- och framställningsprocessen samt självvärderingen"
+                }
+              ],
+              "tavoitteetKohde": {
+                "fi": "Moduulin tavoitteena on, että opiskelija",
+                "sv": "Målen för modulen är att den studerande ska"
+              },
+              "tavoitteet": [
+                {
+                  "fi": "antaa erityisen näytön lukioaikaisesta osaamisestaan ja harrastuneisuudestaan käsityössä",
+                  "sv": "genom en särskild prestation visa prov på sitt intresse för slöjd och de ämneskunskaper och färdigheter som den studerande har utvecklat under gymnasiestudierna"
+                },
+                {
+                  "fi": "osoittaa osaamistaan laadukkaiden käsityötuotteiden omaehtoisessa suunnittelussa, valmistuksessa sekä oppimisensa arvioinnissa",
+                  "sv": "visa sin förmåga att självständigt planera och framställa slöjdprodukter av hög kvalitet samt bedöma sitt kunnande"
+                },
+                {
+                  "fi": "osoittaa hallitsevansa käsityöprosessiin sisältyvät tavoitteiden asettamisen, ideoinnin ja suunnittelun vaiheet ja vaatimukset",
+                  "sv": "visa att hen känner till och behärskar olika skeden och krav som är förknippade med arbetsprocessen i slöjd; att ställa upp mål, skapa en idé och planera"
+                },
+                {
+                  "fi": "hallitsee, seuraa ja arvioi käyttämiään resursseja, työskentelyään ja oppimisprosessiaan",
+                  "sv": "behärska, följa upp och utvärdera sitt arbete, sin lärprocess samt de resurser hen använder"
+                },
+                {
+                  "fi": "osaa ottaa tuotteessa tai teoksessa huomioon esteettisyyden, eettisyyden, omaehtoisuuden näkökulmat ja ekologisuuden vaatimukset",
+                  "sv": "i en självständigt planerad produkt kunna ta i beaktande estetiska och etiska aspekter samt ekologiska krav"
+                },
+                {
+                  "fi": "osaa ratkaista tuotteen tai teoksen toimivuuden, taloudellisuuden, ergonomisuuden, innovatiivisuuden ja teknisen toteutustavan vaatimukset käyttöympäristössään.",
+                  "sv": "kunna avgöra vilka krav som ställs på produkten eller verket i dess bruksmiljö vad gäller hur fungerande, ekonomisk, ergonomisk, innovativ och tekniskt utformad den är."
+                }
+              ]
+            },
+            {
+              "koodi": {
+                "koodiUri": "moduulikoodistolops2021_muld6#1",
+                "nimi": { "sv": "Gymnasiediplom i musik", "fi": "Musiikin lukiodiplomi " }
+              },
+              "linkki": {},
+              "linkinAltTeksti": {},
+              "sisallot": [
+                {
+                  "fi": "opiskelijan musiikillinen omaelämäkerta, musiikkiprojekti tai musiikillinen näytesalkku, yhteenveto ja arvioitsijoiden lausunto",
+                  "sv": "den studerandes musikaliska självbiografi, ett musikprojekt eller en musikportfölj, ett sammandrag och ett utlåtande av bedömarna"
+                },
+                {
+                  "fi": "erilaiset toteutustavat ja osa-alueet",
+                  "sv": "olika arbetssätt och delområden"
+                }
+              ],
+              "tavoitteetKohde": {
+                "fi": "Moduulin tavoitteena on, että opiskelija",
+                "sv": "Målen för modulen är att den studerande ska"
+              },
+              "tavoitteet": [
+                {
+                  "fi": "antaa lukioaikanaan näytön musiikillisesta erityisosaamisestaan ja erityisestä harrastuneisuudestaan musiikissa",
+                  "sv": "genom en särskild prestation visa prov på sitt intresse för musik och de ämneskunskaper och färdigheter som den studerande har utvecklat under gymnasiestudierna"
+                },
+                {
+                  "fi": "osoittaa musiikillista osaamistaan ja harrastuneisuuttaan valmistamalla musiikin taidollista ja tiedollista hallintaa osoittavan projektin tai kokoamalla näytesalkun lukioaikaisista musiikkiopinnoistaan ja  toiminnastaan.",
+                  "sv": "visa sitt musikaliska kunnande och intresse genom att förbereda ett projekt som påvisar kunskaper och färdigheter i musik eller genom att sammanställa en portfölj över sina musikstudier och sin musikaliska verksamhet under gymnasietiden."
+                }
+              ]
+            },
+            {
+              "koodi": {
+                "koodiUri": "moduulikoodistolops2021_lild4#1",
+                "nimi": {
+                  "fi": "Liikunnan lukiodiplomi ",
+                  "sv": "Gymnasiediplom i gymnastik"
+                }
+              },
+              "linkki": {},
+              "linkinAltTeksti": {},
+              "sisallot": [
+                {
+                  "fi": "muodostuvat liikuntakykyisyyden, liikuntatietojen, erityisosaamisen, harrastuneisuuden ja yhteistyötaitojen sekä portfolion muodossa tehtävän itsearvioinnin muodostamasta kokonaisuudesta.",
+                  "sv": "omfattar en helhet som innehåller delområdena fysisk prestationsförmåga, kunskap om gymnastik och idrott, specialkunnande, intresse och samarbetsförmåga samt självvärdering i form av en portfölj"
+                }
+              ],
+              "tavoitteetKohde": {
+                "fi": "Moduulin tavoitteena on, että opiskelija",
+                "sv": "Målen för modulen är att den studerande ska"
+              },
+              "tavoitteet": [
+                {
+                  "fi": "antaa erityisen näytön lukioaikaisesta osaamisestaan ja harrastuneisuudestaan liikunnassa",
+                  "sv": "genom en särskild prestation visa prov på sitt intresse för gymnastik och de ämneskunskaper och färdigheter som den studerande har utvecklat under gymnasiestudierna"
+                },
+                {
+                  "fi": "pohtii monipuolisesti liikunnan merkitystä elämässään samalla kehittäen fyysistä toimintakykyään, liikunnallista erityisosaamistaan, harrastuneisuuttaan ja yhteistyökykyjään.",
+                  "sv": "ska på ett mångsidigt sätt kunna reflektera över betydelsen av fysisk aktivitet i sitt liv och samtidigt utveckla sin fysiska funktionsförmåga, sitt fysiska specialkunnande och intresse samt sin samarbetsförmåga."
+                }
+              ]
+            }
+          ],
+          "kielivalikoima": {
+            "A1Kielet": [
+              {
+                "koodiUri": "kieli_en#1",
+                "nimi": { "en": "English", "sv": "engelska", "fi": "englanti" }
+              }
+            ],
+            "A2Kielet": [],
+            "B1Kielet": [
+              {
+                "koodiUri": "kieli_sv#1",
+                "nimi": { "fi": "ruotsi", "en": "Swedish", "sv": "svenska" }
+              }
+            ],
+            "B2Kielet": [
+              {
+                "koodiUri": "kieli_de#1",
+                "nimi": { "fi": "saksa", "en": "German", "sv": "tyska" }
+              },
+              {
+                "koodiUri": "kieli_ru#1",
+                "nimi": { "en": "Russian", "fi": "venäjä", "sv": "ryska" }
+              }
+            ],
+            "B3Kielet": [
+              {
+                "koodiUri": "kieli_de#1",
+                "nimi": { "fi": "saksa", "en": "German", "sv": "tyska" }
+              },
+              {
+                "koodiUri": "kieli_ru#1",
+                "nimi": { "en": "Russian", "fi": "venäjä", "sv": "ryska" }
+              },
+              {
+                "koodiUri": "kieli_fr#1",
+                "nimi": { "fi": "ranska", "en": "French", "sv": "franska" }
+              },
+              {
+                "koodiUri": "kieli_es#1",
+                "nimi": { "fi": "espanja", "en": "Spanish, Castilian", "sv": "spanska" }
+              },
+              {
+                "koodiUri": "kieli_ja#1",
+                "nimi": { "fi": "japani", "en": "Japanese", "sv": "japanska" }
+              }
+            ],
+            "aidinkielet": [],
+            "muutKielet": []
+          },
+          "ammattinimikkeet": [],
+          "asiasanat": [
+            { "kieli": "fi", "arvo": "yleislukio" },
+            { "kieli": "fi", "arvo": "esports" },
+            { "kieli": "fi", "arvo": "pesäpallo" },
+            { "kieli": "fi", "arvo": "jääkiekko" }
+          ],
+          "opetus": {
+            "maksullisuustyyppi": "maksuton",
+            "maksullisuusKuvaus": {
+              "en": "<p>The education is given free of charge.</p>",
+              "fi": "<p>Lukiokoulutus on ilmaista.</p>"
+            },
+            "suunniteltuKestoKuvaus": {
+              "en": "<p>The length of studies can vary from a shorter option to a longer option depending on your available time.</p>",
+              "fi": "<p>Lukion voi suorittaa myös lyhyemmässä tai pidemmässä ajassa.</p>"
+            },
+            "suunniteltuKestoVuodet": 3,
+            "onkoApuraha": false,
+            "lisatiedot": [],
+            "suunniteltuKestoKuukaudet": 0,
+            "opetustapaKuvaus": {
+              "en": "<p>Our education process uses contact teaching.</p>",
+              "fi": "<p>Opetus annetaan lähiopetuksena.</p>"
+            },
+            "opetuskieletKuvaus": {
+              "en": "<p>Teaching students is done by using Finnish.</p>",
+              "fi": "<p>Opetuskieli on suomi.</p>"
+            },
+            "opetustapa": [
+              {
+                "koodiUri": "opetuspaikkakk_1#1",
+                "nimi": {
+                  "fi": "Lähiopetus",
+                  "sv": "Närundervisning",
+                  "en": "Contact teaching"
+                }
+              }
+            ],
+            "opetusaikaKuvaus": {
+              "en": "<p>Teaching hours are between 8 a.m. and 4 p.m.</p>",
+              "fi": "<p>Opetus tapahtuu kello 8.00-16.00.</p>"
+            },
+            "opetuskieli": [
+              {
+                "koodiUri": "oppilaitoksenopetuskieli_1#2",
+                "nimi": { "sv": "finska", "fi": "suomi", "en": "Finnish" }
+              }
+            ],
+            "opetusaika": [
+              {
+                "koodiUri": "opetusaikakk_1#1",
+                "nimi": {
+                  "sv": "Dagundervisning",
+                  "en": "Day time teaching",
+                  "fi": "Päiväopetus"
+                }
+              }
+            ]
+          },
+          "yhteyshenkilot": [
+            {
+              "nimi": { "en": "Marko Timo", "fi": "Marko Timo" },
+              "titteli": { "en": "Principal", "fi": "Rehtori" },
+              "sahkoposti": {
+                "en": "marko.timo@alajarvi.fi",
+                "fi": "marko.timo@alajarvi.fi"
+              },
+              "puhelinnumero": { "en": "+358444659450", "fi": "62900" },
+              "wwwSivu": {
+                "en": "https://lukio.edualajarvi.fi/",
+                "fi": "https://lukio.edualajarvi.fi/"
+              }
+            }
+          ],
+          "yleislinja": true,
+          "tyyppi": "lk"
+        },
+        "hakutiedot": [
+          {
+            "hakuOid": "1.2.246.562.29.00000000000000021303",
+            "nimi": {
+              "en": "Joint application to upper secondary education and preparatory education 2023",
+              "fi": "Perusopetuksen jälkeisen koulutuksen yhteishaku 2023",
+              "sv": "Gemensam ansökan till utbildning efter den grundläggande utbildningen 2023"
+            },
+            "hakutapa": {
+              "koodiUri": "hakutapa_01#1",
+              "nimi": {
+                "fi": "Yhteishaku",
+                "sv": "Gemensam ansökan",
+                "en": "Joint application"
+              }
+            },
+            "koulutuksenAlkamiskausi": {
+              "alkamiskausityyppi": "alkamiskausi ja -vuosi",
+              "henkilokohtaisenSuunnitelmanLisatiedot": {},
+              "koulutuksenAlkamiskausi": {
+                "koodiUri": "kausi_s#1",
+                "nimi": { "sv": "Höst", "en": "Autumn", "fi": "Syksy" }
+              },
+              "koulutuksenAlkamisvuosi": "2023"
+            },
+            "kohdejoukko": {
+              "koodiUri": "haunkohdejoukko_11#1",
+              "nimi": {
+                "fi": "Perusopetuksen jälkeisen koulutuksen yhteishaku",
+                "sv": "Gemensam ansökan till utbildning efter grundläggande utbildning"
+              }
+            },
+            "hakukohteet": [
+              {
+                "tila": "julkaistu",
+                "hakulomakeKuvaus": {},
+                "pohjakoulutusvaatimusTarkenne": {},
+                "aloituspaikat": { "lukumaara": 108, "kuvaus": {} },
+                "hakulomaketyyppi": "ataru",
+                "pohjakoulutusvaatimus": [
+                  {
+                    "koodiUri": "pohjakoulutusvaatimuskouta_pk#1",
+                    "nimi": { "fi": "Peruskoulu", "sv": "Grundskola", "en": "Peruskoulu" }
+                  }
+                ],
+                "hakulomakeLinkki": {
+                  "fi": "https://untuvaopintopolku.fi/hakemus/hakukohde/1.2.246.562.20.00000000000000021958?lang=fi",
+                  "sv": "https://untuvaopintopolku.fi/hakemus/hakukohde/1.2.246.562.20.00000000000000021958?lang=sv",
+                  "en": "https://untuvaopintopolku.fi/hakemus/hakukohde/1.2.246.562.20.00000000000000021958?lang=en"
+                },
+                "koulutuksenAlkamiskausi": {
+                  "alkamiskausityyppi": "alkamiskausi ja -vuosi",
+                  "henkilokohtaisenSuunnitelmanLisatiedot": {},
+                  "koulutuksenAlkamiskausi": {
+                    "koodiUri": "kausi_s#1",
+                    "nimi": { "sv": "Höst", "en": "Autumn", "fi": "Syksy" }
+                  },
+                  "koulutuksenAlkamisvuosi": "2023"
+                },
+                "hakulomakeAtaruId": "b1646055-f5a4-428d-9ffa-838512e10a44",
+                "esikatselu": true,
+                "hasValintaperustekuvausData": false,
+                "modified": "2022-10-14T10:52:35",
+                "jarjestyspaikka": {
+                  "paikkakunta": {
+                    "koodiUri": "kunta_005",
+                    "nimi": { "fi": "Alajärvi", "sv": "Alajärvi" }
+                  },
+                  "nimi": {
+                    "fi": "Alajärven lukio",
+                    "sv": "Alajärven lukio",
+                    "en": "Alajärven lukio"
+                  },
+                  "oid": "1.2.246.562.10.50460470417",
+                  "jarjestaaUrheilijanAmmKoulutusta": false
+                },
+                "nimi": { "en": "Yleislinja", "fi": "Lukion yleislinja" },
+                "hakuajat": [
+                  {
+                    "alkaa": "2023-02-21T08:00",
+                    "paattyy": "2023-03-21T15:00",
+                    "formatoituPaattyy": {
+                      "fi": "21.3.2023 klo 15:00",
+                      "sv": "21.3.2023 kl. 15:00",
+                      "en": "Mar. 21, 2023 at 03:00 PM UTC+2"
+                    },
+                    "formatoituAlkaa": {
+                      "fi": "21.2.2023 klo 08:00",
+                      "sv": "21.2.2023 kl. 08:00",
+                      "en": "Feb. 21, 2023 at 08:00 AM UTC+2"
+                    },
+                    "hakuAuki": false,
+                    "hakuMennyt": false
+                  }
+                ],
+                "hakukohteenLinja": {
+                  "alinHyvaksyttyKeskiarvo": 7.0,
+                  "lisatietoa": {
+                    "en": "<p>7,0</p>",
+                    "fi": "<p>Jos haet myös KOVA-akatemiaan:</p><p>· Täytä hakemus oppilaitokseen opintopolussa yhteishaussa ja </p><p>· Täytä erillishakemus osoitteessa <a href=\"http://www.kovaakatemia.fi/\" rel=\"noopener noreferrer\" target=\"_blank\">www.kovaakatemia.fi</a></p><p></p><p></p>"
+                  },
+                  "painotetutArvosanat": []
+                },
+                "hakukohdeOid": "1.2.246.562.20.00000000000000021958",
+                "organisaatio": {
+                  "paikkakunta": {
+                    "koodiUri": "kunta_005",
+                    "nimi": { "fi": "Alajärvi", "sv": "Alajärvi" }
+                  },
+                  "nimi": {
+                    "fi": "Alajärven lukio",
+                    "sv": "Alajärven lukio",
+                    "en": "Alajärven lukio"
+                  },
+                  "oid": "1.2.246.562.10.54943480589"
+                },
+                "metadata": {
+                  "pistehistoria": [
+                    {
+                      "tarjoaja": "1.2.246.562.10.50460470417",
+                      "hakukohdekoodi": {
+                        "koodiUri": "hakukohteet_000",
+                        "nimi": { "sv": "Gymnasium", "fi": "Lukio" }
+                      },
+                      "pisteet": 12.00,
+                      "vuosi": "2018",
+                      "valintatapajonoOid": "15204349710893872952965419072836",
+                      "hakukohdeOid": "1.2.246.562.20.25631786289",
+                      "hakuOid": "1.2.246.562.29.55739081531",
+                      "valintatapajonoTyyppi": {
+                        "koodiUri": "valintatapajono_yp",
+                        "nimi": {
+                          "sv": "Totalpoäng",
+                          "en": "Total score",
+                          "fi": "Yhteispisteet"
+                        }
+                      }
+                    },
+                    {
+                      "tarjoaja": "1.2.246.562.10.50460470417",
+                      "hakukohdekoodi": {
+                        "koodiUri": "hakukohteet_000",
+                        "nimi": { "sv": "Gymnasium", "fi": "Lukio" }
+                      },
+                      "pisteet": 7.2,
+                      "vuosi": "2022",
+                      "valintatapajonoOid": "1649413967221888534857780379887",
+                      "hakukohdeOid": "1.2.246.562.20.00000000000000008445",
+                      "hakuOid": "1.2.246.562.29.00000000000000005368",
+                      "valintatapajonoTyyppi": {
+                        "koodiUri": "valintatapajono_yp",
+                        "nimi": {
+                          "sv": "Totalpoäng",
+                          "en": "Total score",
+                          "fi": "Yhteispisteet"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "formatoituModified": {
+                  "fi": "14.10.2022 klo 10:52",
+                  "sv": "14.10.2022 kl. 10:52",
+                  "en": "Oct. 14, 2022 at 10:52 AM UTC+3"
+                },
+                "valintaperusteId": "a08fd02a-9c66-437d-99eb-3e2b9003b334"
+              }
+            ]
+          }
+        ],
+        "formatoituModified": {
+          "fi": "12.7.2022 klo 20:02",
+          "sv": "12.7.2022 kl. 20:02",
+          "en": "Jul. 12, 2022 at 08:02 PM UTC+3"
+        },
+        "koulutustyyppi": "lk"
+      }
+    }
+  },
+  {
+    "method": "GET",
     "url": "http://localhost:3005/konfo-backend/koulutus/1.2.246.562.13.00000000000000001022",
     "response": {
       "status": 200,

--- a/src/main/app/playwright/mocks/komoto-pistelaskuri.mocks.json
+++ b/src/main/app/playwright/mocks/komoto-pistelaskuri.mocks.json
@@ -490,7 +490,15 @@
                       "vuosi": "2018",
                       "valintatapajonoOid": "15204349710893872952965419072834",
                       "hakukohdeOid": "1.2.246.562.20.25631786289",
-                      "hakuOid": "1.2.246.562.29.55739081531"
+                      "hakuOid": "1.2.246.562.29.55739081531",
+                      "valintatapajonoTyyppi": {
+                        "koodiUri": "valintatapajono_tv",
+                        "nimi": {
+                          "sv": "Provpoäng",
+                          "en": "Exam score",
+                          "fi": "Koepisteet"
+                        }
+                      }
                     },
                     {
                       "tarjoaja": "1.2.246.562.10.50460470417",
@@ -502,7 +510,15 @@
                       "vuosi": "2022",
                       "valintatapajonoOid": "1649413967221888534857780379884",
                       "hakukohdeOid": "1.2.246.562.20.00000000000000008445",
-                      "hakuOid": "1.2.246.562.29.00000000000000005368"
+                      "hakuOid": "1.2.246.562.29.00000000000000005368",
+                      "valintatapajonoTyyppi": {
+                        "koodiUri": "valintatapajono_tv",
+                        "nimi": {
+                          "sv": "Provpoäng",
+                          "en": "Exam score",
+                          "fi": "Koepisteet"
+                        }
+                      }
                     }
                   ]
                 },

--- a/src/main/app/public/locales/fi/translation.json
+++ b/src/main/app/public/locales/fi/translation.json
@@ -672,6 +672,9 @@
       "alin-keskiarvo": "sisäänpääsyn alin keskiarvo tai pistemäärä",
       "pisteesi": "arvioitu pistemääräsi",
       "alin-pisteet": "sisäänpääsyn alin pistemäärä",
+      "todistusvalinta": "valintapisteet",
+      "yhteispisteet": "valintapisteet ja pääsykoe",
+      "koepisteet": "pääsykoe",
       "poista": "Poista tietosi",
       "saavutettavuus": {
         "saate": "Sisäänpääsyn alin pisteraja on ollut kohteelle {{kohde}}",

--- a/src/main/app/public/locales/fi/translation.json
+++ b/src/main/app/public/locales/fi/translation.json
@@ -669,11 +669,12 @@
       "info-rohkaisu": "Pistelasku on suuntaa antava. Koulutukseen kannattaa hakea, vaikka pistemääräsi ei olisikaan aiempien vuosien tasolla.",
       "ei-tuloksia": "Hakukohteesta ei ole aiempien vuosien pistetietoja",
       "keskiarvosi": "arvioitu keskiarvosi",
-      "alin-keskiarvo": "sisäänpääsyn alin keskiarvo tai pistemäärä",
+      "alin-keskiarvo": "sisäänpääsyn alin keskiarvo",
       "pisteesi": "arvioitu pistemääräsi",
       "alin-pisteet": "sisäänpääsyn alin pistemäärä",
       "todistusvalinta": "valintapisteet",
       "yhteispisteet": "valintapisteet ja pääsykoe",
+      "yhteispisteet-lukio": "keskiarvo + pääsykoe ja/tai lisänäyttö",
       "koepisteet": "pääsykoe",
       "poista": "Poista tietosi",
       "saavutettavuus": {

--- a/src/main/app/public/locales/fi/translation.json
+++ b/src/main/app/public/locales/fi/translation.json
@@ -680,7 +680,7 @@
         "saate": "Sisäänpääsyn alin pisteraja on ollut kohteelle {{kohde}}",
         "pisteet": "Arvioitu pistemääräsi on {{tulos}}",
         "ka": "Arvioitu keskiarvosi on {{keskiarvo}}",
-        "vuosipiste": "Vuonna {{vuosi}}: {{pisteet}} pistettä.",
+        "vuosipiste": "Vuonna {{vuosi}}: {{pisteet}} pistettä",
         "vuosika": "Vuonna {{vuosi}}: {{pisteet}} keskiarvolla."
       },
       "hakukohde": {

--- a/src/main/app/src/colors.ts
+++ b/src/main/app/src/colors.ts
@@ -21,6 +21,8 @@ export const colors = {
   verminal: '#5BCA13',
   sunglow: '#FFCC33',
   kkMagenta: '#990066',
+  koepisteetBlue: '#0041DC',
+  yhteispisteetPink: '#E60895',
 };
 
 // NOTE: kts. speksi Invision -> Oppija styleguide -> Konfo-UI colors

--- a/src/main/app/src/components/laskuri/graafi/AccessibleGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/AccessibleGraafi.tsx
@@ -47,7 +47,9 @@ const hakukohdeToPisterajat = (
         : t('pistelaskuri.graafi.saavutettavuus.vuosipiste', {
             vuosi: historia.vuosi,
             pisteet: formatDouble(historia.pisteet),
-          }) + getPistetyyppiText(historia.valintatapajonoTyyppi?.koodiUri)
+          }) +
+          getPistetyyppiText(historia.valintatapajonoTyyppi?.koodiUri, t) +
+          '.'
     );
   return join(pisterajat, ' ');
 };

--- a/src/main/app/src/components/laskuri/graafi/AccessibleGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/AccessibleGraafi.tsx
@@ -10,7 +10,12 @@ import { localize } from '#/src/tools/localization';
 import { formatDouble } from '#/src/tools/utils';
 import { Hakukohde, PisteHistoria } from '#/src/types/HakukohdeTypes';
 
-import { GRAAFI_MIN_YEAR, MAX_ITEMS } from './GraafiUtil';
+import {
+  GRAAFI_MIN_YEAR,
+  MAX_ITEMS,
+  containsOnlyTodistusvalinta,
+  getPistetyyppiText,
+} from './GraafiUtil';
 import { HakupisteLaskelma, ENSISIJAINEN_SCORE_BONUS } from '../Keskiarvo';
 
 type Props = {
@@ -34,12 +39,15 @@ const hakukohdeToPisterajat = (
     )
     .slice(0, MAX_ITEMS)
     .map((historia: PisteHistoria) =>
-      t(
-        isLukio
-          ? 'pistelaskuri.graafi.saavutettavuus.vuosika'
-          : 'pistelaskuri.graafi.saavutettavuus.vuosipiste',
-        { vuosi: historia.vuosi, pisteet: formatDouble(historia.pisteet) }
-      )
+      isLukio && containsOnlyTodistusvalinta(hakukohde)
+        ? t('pistelaskuri.graafi.saavutettavuus.vuosika', {
+            vuosi: historia.vuosi,
+            pisteet: formatDouble(historia.pisteet),
+          })
+        : t('pistelaskuri.graafi.saavutettavuus.vuosipiste', {
+            vuosi: historia.vuosi,
+            pisteet: formatDouble(historia.pisteet),
+          }) + getPistetyyppiText(historia.valintatapajonoTyyppi?.koodiUri)
     );
   return join(pisterajat, ' ');
 };

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -212,7 +212,7 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
                       }}
                     />
                     {isLukio
-                      ? getLukioPisteText(isTodistusvalinta, valintatapajonoTyyppi, t)
+                      ? getLukioPisteText(valintatapajonoTyyppi, t)
                       : t('pistelaskuri.graafi.alin-pisteet') +
                         getPistetyyppiText(valintatapajonoTyyppi, t)}
                   </Typography>

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -186,7 +186,8 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
             <PisteGraafi
               hakukohde={hakukohde}
               tulos={calculatedTulos}
-              isLukio={isTodistusvalinta}
+              isLukio={isLukio}
+              isTodistusvalinta={isTodistusvalinta}
             />
             <Box className={classes.legend} aria-hidden={true}>
               {getUniquePistetyypit(hakukohde).map((valintatapajonoTyyppi) => (
@@ -203,10 +204,10 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
                         backgroundColor: getStyleByPistetyyppi(valintatapajonoTyyppi),
                       }}
                     />
-                    {isTodistusvalinta
+                    {isLukio
                       ? t('pistelaskuri.graafi.alin-keskiarvo')
                       : t('pistelaskuri.graafi.alin-pisteet') +
-                        getPistetyyppiText(valintatapajonoTyyppi)}
+                        getPistetyyppiText(valintatapajonoTyyppi, t)}
                   </Typography>
                 </>
               ))}
@@ -225,7 +226,7 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
                     }}
                   />
                   {t(
-                    isTodistusvalinta
+                    isLukio
                       ? 'pistelaskuri.graafi.keskiarvosi'
                       : 'pistelaskuri.graafi.pisteesi'
                   )}

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -26,6 +26,7 @@ import {
   getStyleByPistetyyppi,
   getPistetyyppiText,
   getUniquePistetyypit,
+  getLukioPisteText,
 } from './GraafiUtil';
 import { PainotetutArvosanat } from './PainotetutArvosanat';
 import { PisteGraafi } from './PisteGraafi';
@@ -211,7 +212,7 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
                       }}
                     />
                     {isLukio
-                      ? t('pistelaskuri.graafi.alin-keskiarvo')
+                      ? getLukioPisteText(isTodistusvalinta, valintatapajonoTyyppi, t)
                       : t('pistelaskuri.graafi.alin-pisteet') +
                         getPistetyyppiText(valintatapajonoTyyppi, t)}
                   </Typography>

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -21,6 +21,7 @@ import { Hakukohde } from '#/src/types/HakukohdeTypes';
 import { Hakutieto } from '#/src/types/ToteutusTypes';
 
 import { AccessibleGraafi } from './AccessibleGraafi';
+import { getStyleByPistetyyppi } from './GraafiUtil';
 import { PainotetutArvosanat } from './PainotetutArvosanat';
 import { PisteGraafi } from './PisteGraafi';
 import { Kouluaineet, kopioiKouluaineetPainokertoimilla } from '../aine/Kouluaine';
@@ -163,6 +164,27 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
     setHakukohde(uusiHakukohde);
   };
 
+  const getTextKeyByPistetyyppi = (pistetyyppi: string): string => {
+    switch (pistetyyppi) {
+      case 'valintatapajono_yp':
+        return ` (${t('pistelaskuri.graafi.yhteispisteet')})`;
+      case 'valintatapajono_kp':
+        return ` (${t('pistelaskuri.graafi.koepisteet')})`;
+      case 'valintatapajono_tv':
+        return ` (${t('pistelaskuri.graafi.todistusvalinta')})`;
+      default:
+        return ''; // valintatapajono_m tai tieto puuttuu
+    }
+  };
+
+  const getUniquePistetyypit = () => {
+    const pistetyypit = hakukohde?.metadata?.pistehistoria?.map(
+      (pistehistoria) => pistehistoria.valintatapajonoTyyppi
+    );
+    const uniikitPistetyypit = new Set(pistetyypit);
+    return Array.from(uniikitPistetyypit);
+  };
+
   return (
     <StyledBox>
       <FormControl variant="standard" className={classes.hakukohdeControl}>
@@ -198,14 +220,30 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
               isLukio={isLukio}
             />
             <Box className={classes.legend} aria-hidden={true}>
-              <Typography sx={{ fontSize: '0.875rem' }}>
-                <Box className={classes.legendScores} />
-                {t(
-                  isLukio
-                    ? 'pistelaskuri.graafi.alin-keskiarvo'
-                    : 'pistelaskuri.graafi.alin-pisteet'
-                )}
-              </Typography>
+              {getUniquePistetyypit().map((valintatapajonoTyyppi) => (
+                <>
+                  <Typography sx={{ fontSize: '0.875rem' }}>
+                    <Box
+                      sx={{
+                        width: '12px',
+                        height: '12px',
+                        marginLeft: '24px',
+                        marginRight: '6px',
+                        verticalAlign: 'middle',
+                        display: 'inline-block',
+                        backgroundColor: getStyleByPistetyyppi(
+                          valintatapajonoTyyppi?.koodiUri
+                        ),
+                      }}
+                    />
+                    {isLukio
+                      ? t('pistelaskuri.graafi.alin-keskiarvo')
+                      : t('pistelaskuri.graafi.alin-pisteet') +
+                        getTextKeyByPistetyyppi(valintatapajonoTyyppi?.koodiUri)}
+                  </Typography>
+                </>
+              ))}
+
               {tulos && (
                 <Typography sx={{ fontSize: '0.875rem' }}>
                   <Box className={classes.legendScore} />

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -24,6 +24,7 @@ import { AccessibleGraafi } from './AccessibleGraafi';
 import {
   containsOnlyTodistusvalinta,
   getStyleByPistetyyppi,
+  getPistetyyppiText,
   getUniquePistetyypit,
 } from './GraafiUtil';
 import { PainotetutArvosanat } from './PainotetutArvosanat';
@@ -153,19 +154,6 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
     setHakukohde(uusiHakukohde);
   };
 
-  const getTextKeyByPistetyyppi = (pistetyyppi: string): string => {
-    switch (pistetyyppi) {
-      case 'valintatapajono_yp':
-        return ` (${t('pistelaskuri.graafi.yhteispisteet')})`;
-      case 'valintatapajono_kp':
-        return ` (${t('pistelaskuri.graafi.koepisteet')})`;
-      case 'valintatapajono_tv':
-        return ` (${t('pistelaskuri.graafi.todistusvalinta')})`;
-      default:
-        return ''; // valintatapajono_m tai tieto puuttuu
-    }
-  };
-
   return (
     <StyledBox>
       <FormControl variant="standard" className={classes.hakukohdeControl}>
@@ -218,7 +206,7 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
                     {isTodistusvalinta
                       ? t('pistelaskuri.graafi.alin-keskiarvo')
                       : t('pistelaskuri.graafi.alin-pisteet') +
-                        getTextKeyByPistetyyppi(valintatapajonoTyyppi)}
+                        getPistetyyppiText(valintatapajonoTyyppi)}
                   </Typography>
                 </>
               ))}

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -46,6 +46,8 @@ const classes = {
   hakukohdeSelect: `${PREFIX}hakukohdeselect`,
   hakukohdeInput: `${PREFIX}hakukohdeinput`,
   legend: `${PREFIX}legend`,
+  pistetyyppiText: `${PREFIX}pistetyyppitext`,
+  pistetyyppiBox: `${PREFIX}pistetyyppibox`,
 };
 
 const StyledBox = styled(Box)(({ theme }) => ({
@@ -192,9 +194,13 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos }: Props) => {
             <Box className={classes.legend} aria-hidden={true}>
               {getUniquePistetyypit(hakukohde).map((valintatapajonoTyyppi) => (
                 <>
-                  <Typography sx={{ fontSize: '0.875rem' }}>
+                  <Typography
+                    className={classes.pistetyyppiText}
+                    sx={{ fontSize: '0.875rem' }}>
                     <Box
+                      className={classes.pistetyyppiBox}
                       sx={{
+                        justifyContent: 'center',
                         width: '12px',
                         height: '12px',
                         marginLeft: '24px',

--- a/src/main/app/src/components/laskuri/graafi/GraafiUtil.test.ts
+++ b/src/main/app/src/components/laskuri/graafi/GraafiUtil.test.ts
@@ -1,4 +1,11 @@
-import { GraafiBoundary, graafiYearModifier } from './GraafiUtil';
+import { Hakukohde, PisteHistoria } from '#/src/types/HakukohdeTypes';
+
+import {
+  GraafiBoundary,
+  containsOnlyTodistusvalinta,
+  getUniquePistetyypit,
+  graafiYearModifier,
+} from './GraafiUtil';
 
 describe('GraafiUtil', () => {
   const currentYear = new Date().getUTCFullYear();
@@ -24,6 +31,273 @@ describe('GraafiUtil', () => {
       expect(graafiYearModifier([2020, currentYear, 2018], GraafiBoundary.MIN)).toEqual(
         0
       );
+    });
+  });
+
+  const blankHakukohde: Hakukohde = {
+    metadata: {
+      pistehistoria: undefined,
+    },
+    aloituspaikat: {
+      lukumaara: undefined,
+      ensikertalaisille: undefined,
+      kuvaus: undefined,
+    },
+    hakuajat: [],
+    hakukohdeOid: '',
+    hakuOid: '',
+    hakulomakeAtaruId: '',
+    hakulomakeKuvaus: {
+      fi: undefined,
+      sv: undefined,
+      en: undefined,
+    },
+    hakulomakeLinkki: {
+      fi: undefined,
+      sv: undefined,
+      en: undefined,
+    },
+    hakulomaketyyppi: '',
+    isHakuAuki: false,
+    jarjestyspaikka: {
+      nimi: {
+        fi: undefined,
+        sv: undefined,
+        en: undefined,
+      },
+      oid: '',
+      paikkakunta: {
+        koodiUri: '',
+        nimi: {
+          fi: undefined,
+          sv: undefined,
+          en: undefined,
+        },
+      },
+      jarjestaaUrheilijanAmmKoulutusta: false,
+    },
+    koulutuksenAlkamiskausi: {
+      alkamiskausityyppi: undefined,
+      henkilokohtaisenSuunnitelmanLisatiedot: {
+        fi: undefined,
+        sv: undefined,
+        en: undefined,
+      },
+      koulutuksenAlkamiskausi: {
+        koodiUri: '',
+        nimi: {
+          fi: undefined,
+          sv: undefined,
+          en: undefined,
+        },
+      },
+      koulutuksenAlkamisvuosi: '',
+      formatoituKoulutuksenalkamispaivamaara: {
+        fi: '',
+        sv: '',
+        en: '',
+      },
+      formatoituKoulutuksenpaattymispaivamaara: {
+        fi: '',
+        sv: '',
+        en: '',
+      },
+    },
+    nimi: {
+      fi: undefined,
+      sv: undefined,
+      en: undefined,
+    },
+    pohjakoulutusvaatimus: [],
+    pohjakoulutusvaatimusTarkenne: {
+      fi: undefined,
+      sv: undefined,
+      en: undefined,
+    },
+    liitteet: [],
+    liitteetOnkoSamaToimitusaika: false,
+    liitteetOnkoSamaToimitusosoite: false,
+    liitteidenToimitusaika: '',
+    formatoituLiitteidentoimitusaika: {
+      fi: '',
+      sv: '',
+      en: '',
+    },
+    liitteidenToimitustapa: '',
+    liitteidenToimitusosoite: {
+      osoite: {
+        osoite: {
+          fi: undefined,
+          sv: undefined,
+          en: undefined,
+        },
+        postinumero: {
+          koodiUri: '',
+          nimi: {
+            fi: undefined,
+            sv: undefined,
+            en: undefined,
+          },
+        },
+      },
+      sahkoposti: '',
+      puhelinnumero: '',
+      verkkosivu: '',
+    },
+    hasValintaperustekuvausData: false,
+  };
+
+  const pistehistoriaTodistusvalinta = {
+    pisteet: 6.17,
+    vuosi: '2018',
+    valintatapajonoTyyppi: {
+      koodiUri: 'valintatapajono_tv',
+      nimi: {
+        sv: 'Provpoäng',
+        en: 'Exam score',
+        fi: 'Koepisteet',
+      },
+    },
+  };
+  const pistehistoriaWithTodistusvalinta2 = {
+    pisteet: 7.2,
+    vuosi: '2022',
+    valintatapajonoTyyppi: {
+      koodiUri: 'valintatapajono_tv',
+      nimi: {
+        sv: 'Provpoäng',
+        en: 'Exam score',
+        fi: 'Koepisteet',
+      },
+    },
+  };
+
+  const pistehistoriaYhteispisteet = {
+    pisteet: 16.0,
+    vuosi: '2023',
+    valintatapajonoTyyppi: {
+      koodiUri: 'valintatapajono_yp',
+      nimi: {
+        sv: 'Total poäng',
+        en: 'Total score',
+        fi: 'Yhteispisteet',
+      },
+    },
+  };
+
+  const pistehistoriaKoepisteet = {
+    pisteet: 16.0,
+    vuosi: '2019',
+    valintatapajonoTyyppi: {
+      koodiUri: 'valintatapajono_kp',
+      nimi: {
+        fi: 'Koepisteet',
+        sv: 'Provpoäng',
+        en: 'Exam score',
+      },
+    },
+  };
+
+  const pistehistoriaMuu = {
+    pisteet: 16.0,
+    vuosi: '2020',
+    valintatapajonoTyyppi: {
+      koodiUri: 'valintatapajono_m',
+      nimi: {
+        fi: 'Muu',
+        sv: 'Annat',
+        en: 'Other',
+      },
+    },
+  };
+
+  const pistehistoriaTuntematon: PisteHistoria = {
+    pisteet: 15.0,
+    vuosi: '2021',
+    valintatapajonoTyyppi: null,
+  };
+
+  describe('containsOnlyTodistusvalinta', () => {
+    it('returns true if there is only valintatapajono_tv', () => {
+      expect(
+        containsOnlyTodistusvalinta({
+          ...blankHakukohde,
+          metadata: {
+            ...blankHakukohde.metadata,
+            pistehistoria: [
+              pistehistoriaTodistusvalinta,
+              pistehistoriaWithTodistusvalinta2,
+            ],
+          },
+        })
+      ).toBeTruthy;
+    });
+
+    it('returns false if there is valintatapajono_tv and some other valintatapa', () => {
+      const hakukohdeWithTodistusvalintaAndYhteispisteet = {
+        ...blankHakukohde,
+        metadata: {
+          ...blankHakukohde.metadata,
+          pistehistoria: [
+            pistehistoriaTodistusvalinta,
+            pistehistoriaWithTodistusvalinta2,
+            pistehistoriaYhteispisteet,
+          ],
+        },
+      };
+      expect(containsOnlyTodistusvalinta(hakukohdeWithTodistusvalintaAndYhteispisteet))
+        .toBeFalsy;
+    });
+
+    it('returns false if there is no valintatapajono_tv', () => {
+      const hakukohdeWithKoepisteet = {
+        ...blankHakukohde,
+        metadata: {
+          ...blankHakukohde.metadata,
+          pistehistoria: [pistehistoriaKoepisteet],
+        },
+      };
+      expect(containsOnlyTodistusvalinta(hakukohdeWithKoepisteet)).toBeFalsy;
+    });
+  });
+
+  describe('getUniquePistetyypit', () => {
+    it('returns only one of each type', () => {
+      const pistehistoriaWithAllTypes: Array<PisteHistoria> = [
+        pistehistoriaTodistusvalinta,
+        pistehistoriaWithTodistusvalinta2,
+        pistehistoriaKoepisteet,
+        pistehistoriaYhteispisteet,
+        pistehistoriaMuu,
+      ];
+      const pistetyypit = getUniquePistetyypit({
+        ...blankHakukohde,
+        metadata: {
+          ...blankHakukohde.metadata,
+          pistehistoria: pistehistoriaWithAllTypes,
+        },
+      });
+      expect(pistehistoriaWithAllTypes.length).toEqual(5);
+      expect(pistetyypit.length).toEqual(4);
+    });
+    it('counts null and "muu" as one unique unknown type', () => {
+      const pistehistoriaAllTypesWithNull = [
+        pistehistoriaTuntematon,
+        pistehistoriaTodistusvalinta,
+        pistehistoriaWithTodistusvalinta2,
+        pistehistoriaKoepisteet,
+        pistehistoriaYhteispisteet,
+        pistehistoriaMuu,
+      ];
+      const pistetyypit = getUniquePistetyypit({
+        ...blankHakukohde,
+        metadata: {
+          ...blankHakukohde.metadata,
+          pistehistoria: pistehistoriaAllTypesWithNull,
+        },
+      });
+      expect(pistehistoriaAllTypesWithNull.length).toEqual(6);
+      expect(pistetyypit.length).toEqual(4);
     });
   });
 });

--- a/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
+++ b/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
-import { Datum } from 'victory';
-
+import { colors } from '#/src/colors';
 import { formatDouble } from '#/src/tools/utils';
 import { Hakukohde, PisteHistoria } from '#/src/types/HakukohdeTypes';
 
@@ -30,12 +29,13 @@ export const graafiYearModifier = (
 };
 
 export type PisteData = {
-  data: Array<Datum>;
-  years: Array<number>;
-  labels: Array<string>;
+  pisteet: number;
+  pisteetLabel: any;
+  vuosi: number;
+  pistetyyppi: string;
 };
 
-export const usePisteHistoria = (hakukohde: Hakukohde): PisteData => {
+export const usePisteHistoria = (hakukohde: Hakukohde): Array<PisteData> => {
   return useMemo(() => {
     const data =
       hakukohde?.metadata?.pistehistoria
@@ -43,12 +43,28 @@ export const usePisteHistoria = (hakukohde: Hakukohde): PisteData => {
           (historia: PisteHistoria) => Number.parseInt(historia.vuosi) >= GRAAFI_MIN_YEAR
         )
         .map((historia: PisteHistoria) => {
-          return { x: Number.parseInt(historia.vuosi), y: historia.pisteet };
+          return {
+            pisteet: historia.pisteet,
+            pisteetLabel: formatDouble(historia.pisteet),
+            vuosi: Number.parseInt(historia.vuosi),
+            pistetyyppi: historia.valintatapajonoTyyppi?.koodiUri,
+          } as PisteData;
         })
-        .sort((a, b) => b.x - a.x)
+        .sort((a, b) => b.vuosi - a.vuosi)
         .slice(0, MAX_ITEMS) || [];
-    const years = data.map((datum: Datum) => datum.x);
-    const labels = data.map((datum: Datum) => formatDouble(datum.y));
-    return { data, years, labels };
+    return data;
   }, [hakukohde]);
+};
+
+export const getStyleByPistetyyppi = (pistetyyppi: string): string => {
+  switch (pistetyyppi) {
+    case 'valintatapajono_yp':
+      return colors.yhteispisteetPink;
+    case 'valintatapajono_kp':
+      return colors.koepisteetBlue;
+    case 'valintatapajono_tv':
+      return colors.verminal;
+    default:
+      return colors.darkGrey; // valintatapajono_m tai tieto puuttuu
+  }
 };

--- a/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
+++ b/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
 
 import { colors } from '#/src/colors';
 import { formatDouble } from '#/src/tools/utils';
@@ -90,8 +90,10 @@ export const containsOnlyTodistusvalinta = (hakukohde: Hakukohde) => {
   );
 };
 
-export const getPistetyyppiText = (pistetyyppi: string | undefined): string => {
-  const { t } = useTranslation();
+export const getPistetyyppiText = (
+  pistetyyppi: string | undefined,
+  t: TFunction
+): string => {
   switch (pistetyyppi) {
     case 'valintatapajono_yp':
       return ` (${t('pistelaskuri.graafi.yhteispisteet')})`;

--- a/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
+++ b/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
@@ -105,3 +105,21 @@ export const getPistetyyppiText = (
       return ''; // valintatapajono_m tai tieto puuttuu
   }
 };
+
+export const getLukioPisteText = (
+  isTodistusvalinta: boolean,
+  pistetyyppi: string | undefined,
+  t: TFunction
+): string => {
+  if (isTodistusvalinta) {
+    return t('pistelaskuri.graafi.alin-keskiarvo'); // tässä ei tarvitse erikseen mainita pistetyyppiä
+  }
+  switch (pistetyyppi) {
+    case 'valintatapajono_yp':
+      return `${t('pistelaskuri.graafi.alin-pisteet')} (${t(
+        'pistelaskuri.graafi.yhteispisteet-lukio'
+      )})`;
+    default:
+      return t('pistelaskuri.graafi.alin-pisteet'); // lukiossa ei pitäisi olla muita valintajonotyyppejä
+  }
+};

--- a/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
+++ b/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
@@ -68,3 +68,18 @@ export const getStyleByPistetyyppi = (pistetyyppi: string): string => {
       return colors.darkGrey; // valintatapajono_m tai tieto puuttuu
   }
 };
+
+export const getUniquePistetyypit = (hakukohde: Hakukohde) => {
+  const pistetyypit = hakukohde?.metadata?.pistehistoria?.map(
+    (pistehistoria) => pistehistoria?.valintatapajonoTyyppi?.koodiUri
+  );
+  const uniikitPistetyypit = new Set(pistetyypit);
+  return Array.from(uniikitPistetyypit);
+};
+
+export const containsOnlyTodistusvalinta = (hakukohde: Hakukohde) => {
+  return (
+    getUniquePistetyypit(hakukohde).length == 1 &&
+    getUniquePistetyypit(hakukohde).includes('valintatapajono_tv')
+  );
+};

--- a/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
+++ b/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import { useTranslation } from 'react-i18next';
+
 import { colors } from '#/src/colors';
 import { formatDouble } from '#/src/tools/utils';
 import { Hakukohde, PisteHistoria } from '#/src/types/HakukohdeTypes';
@@ -56,7 +58,7 @@ export const usePisteHistoria = (hakukohde: Hakukohde): Array<PisteData> => {
   }, [hakukohde]);
 };
 
-export const getStyleByPistetyyppi = (pistetyyppi: string): string => {
+export const getStyleByPistetyyppi = (pistetyyppi: string | undefined): string => {
   switch (pistetyyppi) {
     case 'valintatapajono_yp':
       return colors.yhteispisteetPink;
@@ -74,6 +76,10 @@ export const getUniquePistetyypit = (hakukohde: Hakukohde) => {
     (pistehistoria) => pistehistoria?.valintatapajonoTyyppi?.koodiUri
   );
   const uniikitPistetyypit = new Set(pistetyypit);
+  // jos on sekä 'muu' että tyhjä, ei listata niitä erikseen
+  if (uniikitPistetyypit.has(undefined) && uniikitPistetyypit.has('valintatapajono_m')) {
+    uniikitPistetyypit.delete(undefined);
+  }
   return Array.from(uniikitPistetyypit);
 };
 
@@ -82,4 +88,18 @@ export const containsOnlyTodistusvalinta = (hakukohde: Hakukohde) => {
     getUniquePistetyypit(hakukohde).length == 1 &&
     getUniquePistetyypit(hakukohde).includes('valintatapajono_tv')
   );
+};
+
+export const getPistetyyppiText = (pistetyyppi: string | undefined): string => {
+  const { t } = useTranslation();
+  switch (pistetyyppi) {
+    case 'valintatapajono_yp':
+      return ` (${t('pistelaskuri.graafi.yhteispisteet')})`;
+    case 'valintatapajono_kp':
+      return ` (${t('pistelaskuri.graafi.koepisteet')})`;
+    case 'valintatapajono_tv':
+      return ` (${t('pistelaskuri.graafi.todistusvalinta')})`;
+    default:
+      return ''; // valintatapajono_m tai tieto puuttuu
+  }
 };

--- a/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
+++ b/src/main/app/src/components/laskuri/graafi/GraafiUtil.ts
@@ -107,18 +107,16 @@ export const getPistetyyppiText = (
 };
 
 export const getLukioPisteText = (
-  isTodistusvalinta: boolean,
   pistetyyppi: string | undefined,
   t: TFunction
 ): string => {
-  if (isTodistusvalinta) {
-    return t('pistelaskuri.graafi.alin-keskiarvo'); // tässä ei tarvitse erikseen mainita pistetyyppiä
-  }
   switch (pistetyyppi) {
     case 'valintatapajono_yp':
       return `${t('pistelaskuri.graafi.alin-pisteet')} (${t(
         'pistelaskuri.graafi.yhteispisteet-lukio'
       )})`;
+    case 'valintatapajono_tv':
+      return t('pistelaskuri.graafi.alin-keskiarvo');
     default:
       return t('pistelaskuri.graafi.alin-pisteet'); // lukiossa ei pitäisi olla muita valintajonotyyppejä
   }

--- a/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
@@ -19,10 +19,11 @@ import { Hakukohde } from '#/src/types/HakukohdeTypes';
 import {
   GRAAFI_MAX_YEAR,
   GRAAFI_MIN_YEAR,
-  usePisteHistoria,
-  PisteData,
   graafiYearModifier,
   GraafiBoundary,
+  PisteData,
+  usePisteHistoria,
+  getStyleByPistetyyppi,
 } from './GraafiUtil';
 import { HakupisteLaskelma, ENSISIJAINEN_SCORE_BONUS } from '../Keskiarvo';
 
@@ -33,14 +34,15 @@ type Props = {
 };
 
 const PisteGraafiLukio = ({ hakukohde, tulos }: Props) => {
-  const { data, years, labels }: PisteData = usePisteHistoria(hakukohde);
+  const data: Array<PisteData> = usePisteHistoria(hakukohde);
+  const years = data.map((datum) => datum.vuosi);
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   const DEFAULT_MAX = 10;
 
   const maxY = (datas: Array<Datum>): number => {
-    const highestScore = datas.map((datum) => datum.y).sort((a, b) => b - a)[0];
+    const highestScore = datas.map((datum) => datum.pisteet).sort((a, b) => b - a)[0];
     return Math.max(DEFAULT_MAX, highestScore);
   };
 
@@ -80,11 +82,13 @@ const PisteGraafiLukio = ({ hakukohde, tulos }: Props) => {
           <VictoryBar
             data={data}
             style={{
-              data: { fill: colors.verminal },
+              data: { fill: ({ datum }) => getStyleByPistetyyppi(datum.pistetyyppi) },
               labels: { fontSize: isSmall ? 32 : 14 },
             }}
             barWidth={isSmall ? 74 : 52}
-            labels={labels}
+            labels={data.map((datum) => datum.pisteetLabel)}
+            x="vuosi"
+            y="pisteet"
           />
           {tulos && (
             <VictoryLine
@@ -113,7 +117,8 @@ const PisteGraafiLukio = ({ hakukohde, tulos }: Props) => {
 };
 
 const PisteGraafiAmmatillinen = ({ hakukohde, tulos }: Props) => {
-  const { data, years, labels }: PisteData = usePisteHistoria(hakukohde);
+  const data: Array<PisteData> = usePisteHistoria(hakukohde);
+  const years = data.map((datum) => datum.vuosi);
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -153,11 +158,13 @@ const PisteGraafiAmmatillinen = ({ hakukohde, tulos }: Props) => {
           <VictoryBar
             data={data}
             style={{
-              data: { fill: colors.verminal },
+              data: { fill: ({ datum }) => getStyleByPistetyyppi(datum.pistetyyppi) },
               labels: { fontSize: isSmall ? 32 : 14 },
             }}
             barWidth={52}
-            labels={labels}
+            labels={data.map((datum) => datum.pisteetLabel)}
+            x="vuosi"
+            y="pisteet"
           />
           {tulos && (
             <VictoryLine

--- a/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
@@ -27,6 +27,37 @@ import {
 } from './GraafiUtil';
 import { HakupisteLaskelma, ENSISIJAINEN_SCORE_BONUS } from '../Keskiarvo';
 
+type LukiopisteProps = {
+  tulos: HakupisteLaskelma;
+  years: Array<number>;
+};
+
+const Lukiopistelaskelma = ({ tulos, years, ...props }: LukiopisteProps) => {
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  return (
+    <VictoryLine
+      {...props}
+      style={{
+        data: { stroke: colors.sunglow, strokeWidth: 3 },
+        labels: { fontSize: isSmall ? 32 : 14 },
+      }}
+      data={[
+        {
+          x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
+          y: tulos.keskiarvoPainotettu,
+        },
+        {
+          x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
+          y: tulos.keskiarvoPainotettu,
+        },
+      ]}
+      labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
+      labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
+    />
+  );
+};
+
 type Props = {
   hakukohde: Hakukohde;
   tulos: HakupisteLaskelma | null;
@@ -91,26 +122,7 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
             x="vuosi"
             y="pisteet"
           />
-          {tulos && (
-            <VictoryLine
-              style={{
-                data: { stroke: colors.sunglow, strokeWidth: 3 },
-                labels: { fontSize: isSmall ? 32 : 14 },
-              }}
-              data={[
-                {
-                  x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
-                  y: tulos.keskiarvoPainotettu,
-                },
-                {
-                  x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
-                  y: tulos.keskiarvoPainotettu,
-                },
-              ]}
-              labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
-              labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
-            />
-          )}
+          {tulos && <Lukiopistelaskelma tulos={tulos} years={years} />}
         </VictoryGroup>
       </VictoryChart>
     </Box>
@@ -169,24 +181,7 @@ const PisteGraafiAmmatillinenJaPaasykoe = ({ hakukohde, tulos, isLukio }: Props)
           />
           {tulos &&
             (isLukio ? (
-              <VictoryLine
-                style={{
-                  data: { stroke: colors.sunglow, strokeWidth: 3 },
-                  labels: { fontSize: isSmall ? 32 : 14 },
-                }}
-                data={[
-                  {
-                    x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
-                    y: tulos.keskiarvoPainotettu,
-                  },
-                  {
-                    x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
-                    y: tulos.keskiarvoPainotettu,
-                  },
-                ]}
-                labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
-                labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
-              />
+              <Lukiopistelaskelma tulos={tulos} years={years} />
             ) : (
               <VictoryLine
                 style={{

--- a/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
@@ -31,9 +31,40 @@ type Props = {
   hakukohde: Hakukohde;
   tulos: HakupisteLaskelma | null;
   isLukio?: boolean;
+  isTodistusvalinta?: boolean;
 };
 
-const PisteGraafiLukio = ({ hakukohde, tulos }: Props) => {
+type LukiopisteProps = {
+  tulos: HakupisteLaskelma;
+  years: Array<number>;
+};
+
+const Lukiopistelaskelma = ({ tulos, years }: LukiopisteProps) => {
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  return (
+    <VictoryLine
+      style={{
+        data: { stroke: colors.sunglow, strokeWidth: 3 },
+        labels: { fontSize: isSmall ? 32 : 14 },
+      }}
+      data={[
+        {
+          x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
+          y: tulos.keskiarvoPainotettu,
+        },
+        {
+          x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
+          y: tulos.keskiarvoPainotettu,
+        },
+      ]}
+      labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
+      labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
+    />
+  );
+};
+
+const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
   const data: Array<PisteData> = usePisteHistoria(hakukohde);
   const years = data.map((datum) => datum.vuosi);
   const theme = useTheme();
@@ -90,33 +121,14 @@ const PisteGraafiLukio = ({ hakukohde, tulos }: Props) => {
             x="vuosi"
             y="pisteet"
           />
-          {tulos && (
-            <VictoryLine
-              style={{
-                data: { stroke: colors.sunglow, strokeWidth: 3 },
-                labels: { fontSize: isSmall ? 32 : 14 },
-              }}
-              data={[
-                {
-                  x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
-                  y: tulos.keskiarvoPainotettu,
-                },
-                {
-                  x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
-                  y: tulos.keskiarvoPainotettu,
-                },
-              ]}
-              labels={[formatDouble(tulos.keskiarvoPainotettu)]}
-              labelComponent={<VictoryLabel renderInPortal dx={isSmall ? 25 : 15} />}
-            />
-          )}
+          {tulos && <Lukiopistelaskelma tulos={tulos} years={years} />}
         </VictoryGroup>
       </VictoryChart>
     </Box>
   );
 };
 
-const PisteGraafiAmmatillinen = ({ hakukohde, tulos }: Props) => {
+const PisteGraafiAmmatillinenJaPaasykoe = ({ hakukohde, tulos, isLukio }: Props) => {
   const data: Array<PisteData> = usePisteHistoria(hakukohde);
   const years = data.map((datum) => datum.vuosi);
   const theme = useTheme();
@@ -166,36 +178,43 @@ const PisteGraafiAmmatillinen = ({ hakukohde, tulos }: Props) => {
             x="vuosi"
             y="pisteet"
           />
-          {tulos && (
-            <VictoryLine
-              style={{
-                data: { stroke: colors.sunglow, strokeWidth: 3 },
-                labels: { fontSize: isSmall ? 32 : 14 },
-              }}
-              data={[
-                {
-                  x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
-                  y: tulos.pisteet + ENSISIJAINEN_SCORE_BONUS,
-                },
-                {
-                  x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
-                  y: tulos.pisteet + ENSISIJAINEN_SCORE_BONUS,
-                },
-              ]}
-              labels={[`${tulos.pisteet + ENSISIJAINEN_SCORE_BONUS}`]}
-              labelComponent={<VictoryLabel renderInPortal dx={isSmall ? 25 : 15} />}
-            />
-          )}
+          {tulos &&
+            (isLukio ? (
+              <Lukiopistelaskelma tulos={tulos} years={years} />
+            ) : (
+              <VictoryLine
+                style={{
+                  data: { stroke: colors.sunglow, strokeWidth: 3 },
+                  labels: { fontSize: isSmall ? 32 : 14 },
+                }}
+                data={[
+                  {
+                    x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
+                    y: tulos.pisteet + ENSISIJAINEN_SCORE_BONUS,
+                  },
+                  {
+                    x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
+                    y: tulos.pisteet + ENSISIJAINEN_SCORE_BONUS,
+                  },
+                ]}
+                labels={['', `${tulos.pisteet + ENSISIJAINEN_SCORE_BONUS}`]}
+                labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
+              />
+            ))}
         </VictoryGroup>
       </VictoryChart>
     </Box>
   );
 };
 
-export const PisteGraafi = ({ hakukohde, tulos, isLukio }: Props) => {
-  return isLukio ? (
-    <PisteGraafiLukio hakukohde={hakukohde} tulos={tulos} />
+export const PisteGraafi = ({ hakukohde, tulos, isLukio, isTodistusvalinta }: Props) => {
+  return isLukio && isTodistusvalinta ? (
+    <PisteGraafiKouluarvosanat hakukohde={hakukohde} tulos={tulos} />
   ) : (
-    <PisteGraafiAmmatillinen hakukohde={hakukohde} tulos={tulos} />
+    <PisteGraafiAmmatillinenJaPaasykoe
+      hakukohde={hakukohde}
+      tulos={tulos}
+      isLukio={isLukio}
+    />
   );
 };

--- a/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
@@ -34,36 +34,6 @@ type Props = {
   isTodistusvalinta?: boolean;
 };
 
-type LukiopisteProps = {
-  tulos: HakupisteLaskelma;
-  years: Array<number>;
-};
-
-const Lukiopistelaskelma = ({ tulos, years }: LukiopisteProps) => {
-  const theme = useTheme();
-  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
-  return (
-    <VictoryLine
-      style={{
-        data: { stroke: colors.sunglow, strokeWidth: 3 },
-        labels: { fontSize: isSmall ? 32 : 14 },
-      }}
-      data={[
-        {
-          x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
-          y: tulos.keskiarvoPainotettu,
-        },
-        {
-          x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
-          y: tulos.keskiarvoPainotettu,
-        },
-      ]}
-      labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
-      labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
-    />
-  );
-};
-
 const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
   const data: Array<PisteData> = usePisteHistoria(hakukohde);
   const years = data.map((datum) => datum.vuosi);
@@ -121,7 +91,26 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
             x="vuosi"
             y="pisteet"
           />
-          {tulos && <Lukiopistelaskelma tulos={tulos} years={years} />}
+          {tulos && (
+            <VictoryLine
+              style={{
+                data: { stroke: colors.sunglow, strokeWidth: 3 },
+                labels: { fontSize: isSmall ? 32 : 14 },
+              }}
+              data={[
+                {
+                  x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
+                  y: tulos.keskiarvoPainotettu,
+                },
+                {
+                  x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
+                  y: tulos.keskiarvoPainotettu,
+                },
+              ]}
+              labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
+              labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
+            />
+          )}
         </VictoryGroup>
       </VictoryChart>
     </Box>
@@ -180,7 +169,24 @@ const PisteGraafiAmmatillinenJaPaasykoe = ({ hakukohde, tulos, isLukio }: Props)
           />
           {tulos &&
             (isLukio ? (
-              <Lukiopistelaskelma tulos={tulos} years={years} />
+              <VictoryLine
+                style={{
+                  data: { stroke: colors.sunglow, strokeWidth: 3 },
+                  labels: { fontSize: isSmall ? 32 : 14 },
+                }}
+                data={[
+                  {
+                    x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
+                    y: tulos.keskiarvoPainotettu,
+                  },
+                  {
+                    x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
+                    y: tulos.keskiarvoPainotettu,
+                  },
+                ]}
+                labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
+                labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
+              />
             ) : (
               <VictoryLine
                 style={{

--- a/src/main/app/src/types/HakukohdeTypes.ts
+++ b/src/main/app/src/types/HakukohdeTypes.ts
@@ -54,7 +54,7 @@ export type ValintatapajonoTyyppi = {
 export type PisteHistoria = {
   pisteet: number;
   vuosi: string;
-  valintatapajonoTyyppi: ValintatapajonoTyyppi;
+  valintatapajonoTyyppi: ValintatapajonoTyyppi | null;
 };
 
 export type Metadata = {

--- a/src/main/app/src/types/HakukohdeTypes.ts
+++ b/src/main/app/src/types/HakukohdeTypes.ts
@@ -45,6 +45,14 @@ export type Hakuaika = {
 export type PisteHistoria = {
   pisteet: number;
   vuosi: string;
+  valintatapajonoTyyppi: {
+    koodiUri: string;
+    nimi: {
+      sv: string;
+      en: string;
+      fi: string;
+    };
+  };
 };
 
 export type Metadata = {

--- a/src/main/app/src/types/HakukohdeTypes.ts
+++ b/src/main/app/src/types/HakukohdeTypes.ts
@@ -42,17 +42,19 @@ export type Hakuaika = {
   formatoituPaattyy: FormatoituAikaleima;
 };
 
+export type ValintatapajonoTyyppi = {
+  koodiUri: string;
+  nimi: {
+    sv: string;
+    en: string;
+    fi: string;
+  };
+};
+
 export type PisteHistoria = {
   pisteet: number;
   vuosi: string;
-  valintatapajonoTyyppi: {
-    koodiUri: string;
-    nimi: {
-      sv: string;
-      en: string;
-      fi: string;
-    };
-  };
+  valintatapajonoTyyppi: ValintatapajonoTyyppi;
 };
 
 export type Metadata = {


### PR DESCRIPTION
* Lisätty hakukohteiden pistehistoriagraafiin värikoodit ja seloste valintajonotyypin mukaan
* Vastaava lisäys saavutettavaan tekstiversioon pistehistoriasta
* Jos lukion pistehistoriassa on käytössä muu valintajonotyyppi kuin todistusvalinta, esitetään graafi pisteiden mukaan skaalattuna eikä kouluarvosana-skaalalla
* Jos valintajonotyypin perusteella ei tiedetä pisteytystä (joko tyyppi muu tai tieto puuttuu), erillinen värikoodi ja ei laiteta pistetyyppiselitettä