### PR TITLE
Oy 4464 Lukiohakukohteen A-kielistä ja B-kielistä siirtyy vain pilkku Opintopolun puolelle

### DIFF
--- a/src/main/app/public/locales/fi/translation.json
+++ b/src/main/app/public/locales/fi/translation.json
@@ -619,7 +619,8 @@
     "opintojakson-kuvaus": "Opintojakson kuvaus",
     "lue-lisaa-opintojaksosta": "Lue lisää opintojaksosta",
     "kuuluu-opintokokonaisuuksiin": "Opintojakso kuuluu seuraaviin opintokokonaisuuksiin:",
-    "taiteenala": "Taiteenalat"
+    "taiteenala": "Taiteenalat",
+    "kaikki-kielet-prefix": "Sisältyvät oppiaineet"
   },
   "header": {
     "siirry-etusivulle": "Siirry Opintopolun etusivulle"

--- a/src/main/app/src/components/common/AllLanguagesTooltip/AllLanguagesTooltip.tsx
+++ b/src/main/app/src/components/common/AllLanguagesTooltip/AllLanguagesTooltip.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { Box } from '@mui/material';
+
+import { usePainotettavatOppiaineetLukiossa } from '#/src/components/common/AllLanguagesTooltip/hooks';
+import { LabelTooltip } from '#/src/components/common/LabelTooltip';
+import { styled } from '#/src/theme';
+import { translate } from '#/src/tools/localization';
+
+const Container = styled(Box)({
+  ['&']: {
+    'margin-left': '0.5rem',
+  },
+});
+
+type Props = {
+  koodiUri: string;
+};
+export const AllLanguagesTooltip = ({ koodiUri }: Props) => {
+  const oppiaineet = usePainotettavatOppiaineetLukiossa();
+  const kielet = oppiaineet
+    ?.filter(
+      (oppiaine) =>
+        oppiaine.koodiUri.startsWith(koodiUri) && oppiaine.koodiUri !== koodiUri
+    )
+    .map((kieli) => translate(kieli.nimi));
+
+  return (
+    <Container>
+      <LabelTooltip title={`Sisältyvät oppiaineet: ${kielet?.join(', ')}`} />
+    </Container>
+  );
+};

--- a/src/main/app/src/components/common/AllLanguagesTooltip/AllLanguagesTooltip.tsx
+++ b/src/main/app/src/components/common/AllLanguagesTooltip/AllLanguagesTooltip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Box } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 
 import { usePainotettavatOppiaineetLukiossa } from '#/src/components/common/AllLanguagesTooltip/hooks';
 import { LabelTooltip } from '#/src/components/common/LabelTooltip';
@@ -17,6 +18,7 @@ type Props = {
   koodiUri: string;
 };
 export const AllLanguagesTooltip = ({ koodiUri }: Props) => {
+  const { t } = useTranslation();
   const oppiaineet = usePainotettavatOppiaineetLukiossa();
   const kielet = oppiaineet
     ?.filter(
@@ -27,7 +29,9 @@ export const AllLanguagesTooltip = ({ koodiUri }: Props) => {
 
   return (
     <Container>
-      <LabelTooltip title={`Sisältyvät oppiaineet: ${kielet?.join(', ')}`} />
+      <LabelTooltip
+        title={`${t('toteutus.kaikki-kielet-prefix')}: ${kielet?.join(', ')}`}
+      />
     </Container>
   );
 };

--- a/src/main/app/src/components/common/AllLanguagesTooltip/hooks.ts
+++ b/src/main/app/src/components/common/AllLanguagesTooltip/hooks.ts
@@ -1,0 +1,13 @@
+import { useQuery } from 'react-query';
+
+import { getKoodistonKoodit } from '#/src/api/konfoApi';
+import { Koodi } from '#/src/types/common';
+
+export const usePainotettavatOppiaineetLukiossa = () => {
+  const { data } = useQuery<Array<Koodi>>(
+    ['getPainotettavatOppiaineetLukiossa'],
+    () => getKoodistonKoodit('painotettavatoppiaineetlukiossa'),
+    { staleTime: Infinity }
+  );
+  return data;
+};

--- a/src/main/app/src/components/laskuri/KeskiarvoTulos.tsx
+++ b/src/main/app/src/components/laskuri/KeskiarvoTulos.tsx
@@ -173,7 +173,7 @@ export const KeskiarvoTulos = ({ tulos, embedded, kouluaineet }: Props) => {
     if (hakukohde) {
       const modifiedAineet = kopioiKouluaineetPainokertoimilla(
         kouluaineet,
-        hakukohde.hakukohteenLinja?.painotetutArvosanat || []
+        hakukohde.hakukohteenLinja?.painotetutArvosanatOppiaineittain || []
       );
       return lukuaineKeskiarvoPainotettu(modifiedAineet);
     }

--- a/src/main/app/src/components/laskuri/graafi/PainotetutArvosanat.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PainotetutArvosanat.tsx
@@ -35,7 +35,7 @@ const PainotettuArvosanaList = ({ painotetutArvosanat }: Props) => {
               'pistelaskuri.graafi.painokerroin'
             )}: ${formatDouble(painotettu.painokerroin)}`}
             {PAINOTETUT_OPPIAINEET_LUKIO_KAIKKI_OPTIONS.includes(
-              painotettu.koodit.oppiaine.koodiUri
+              painotettu.koodit.oppiaine.koodiUri.split('#')[0]
             ) && <AllLanguagesTooltip koodiUri={painotettu.koodit.oppiaine.koodiUri} />}
           </Box>
         </ListItem>

--- a/src/main/app/src/components/laskuri/graafi/PainotetutArvosanat.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PainotetutArvosanat.tsx
@@ -3,7 +3,9 @@ import React, { useState } from 'react';
 import { Box, Typography, List, ListItem, Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
+import { AllLanguagesTooltip } from '#/src/components/common/AllLanguagesTooltip/AllLanguagesTooltip';
 import { MaterialIcon } from '#/src/components/common/MaterialIcon';
+import { PAINOTETUT_OPPIAINEET_LUKIO_KAIKKI_OPTIONS } from '#/src/constants';
 import { styled } from '#/src/theme';
 import { translate } from '#/src/tools/localization';
 import { formatDouble } from '#/src/tools/utils';
@@ -28,9 +30,14 @@ const PainotettuArvosanaList = ({ painotetutArvosanat }: Props) => {
     <List dense={true} sx={{ listStyleType: 'disc', paddingLeft: '3rem' }}>
       {painotetutArvosanat.map((painotettu: PainotettuArvosana, index: number) => (
         <ListItem key={`painotettu-${index}`} sx={{ display: 'list-item' }}>
-          {`${translate(painotettu.koodit.oppiaine.nimi)}, ${t(
-            'pistelaskuri.graafi.painokerroin'
-          )}: ${formatDouble(painotettu.painokerroin)}`}
+          <Box sx={{ display: 'inline-flex', 'align-items': 'center' }}>
+            {`${translate(painotettu.koodit.oppiaine.nimi)}, ${t(
+              'pistelaskuri.graafi.painokerroin'
+            )}: ${formatDouble(painotettu.painokerroin)}`}
+            {PAINOTETUT_OPPIAINEET_LUKIO_KAIKKI_OPTIONS.includes(
+              painotettu.koodit.oppiaine.koodiUri
+            ) && <AllLanguagesTooltip koodiUri={painotettu.koodit.oppiaine.koodiUri} />}
+          </Box>
         </ListItem>
       ))}
     </List>

--- a/src/main/app/src/components/valintaperusteet/PainotetutArvosanat.tsx
+++ b/src/main/app/src/components/valintaperusteet/PainotetutArvosanat.tsx
@@ -3,7 +3,9 @@ import React from 'react';
 import { Box, Divider, Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
+import { AllLanguagesTooltip } from '#/src/components/common/AllLanguagesTooltip/AllLanguagesTooltip';
 import { Heading, HeadingBoundary } from '#/src/components/Heading';
+import { PAINOTETUT_OPPIAINEET_LUKIO_KAIKKI_OPTIONS } from '#/src/constants';
 import { styled } from '#/src/theme';
 import { localize } from '#/src/tools/localization';
 import { formatDouble, toId } from '#/src/tools/utils';
@@ -73,6 +75,15 @@ export const PainotetutArvosanat = ({ arvosanat }: Props) => {
                     <td className={classes.cell}>{getOppiaineName(arvosana.koodit)}</td>
                     <td className={classes.cell}>
                       {formatDouble(arvosana.painokerroin)}
+                    </td>
+                    <td>
+                      {PAINOTETUT_OPPIAINEET_LUKIO_KAIKKI_OPTIONS.includes(
+                        arvosana.koodit.oppiaine.koodiUri
+                      ) && (
+                        <AllLanguagesTooltip
+                          koodiUri={arvosana.koodit.oppiaine.koodiUri}
+                        />
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/src/main/app/src/components/valintaperusteet/PainotetutArvosanat.tsx
+++ b/src/main/app/src/components/valintaperusteet/PainotetutArvosanat.tsx
@@ -78,7 +78,7 @@ export const PainotetutArvosanat = ({ arvosanat }: Props) => {
                     </td>
                     <td>
                       {PAINOTETUT_OPPIAINEET_LUKIO_KAIKKI_OPTIONS.includes(
-                        arvosana.koodit.oppiaine.koodiUri
+                        arvosana.koodit.oppiaine.koodiUri.split('#')[0]
                       ) && (
                         <AllLanguagesTooltip
                           koodiUri={arvosana.koodit.oppiaine.koodiUri}

--- a/src/main/app/src/constants.ts
+++ b/src/main/app/src/constants.ts
@@ -118,3 +118,11 @@ export enum MAKSULLISUUSTYYPPI {
   MAKSUTON = 'maksuton',
   LUKUVUOSIMAKSU = 'lukuvuosimaksu',
 }
+
+export const PAINOTETUT_OPPIAINEET_LUKIO_KAIKKI_OPTIONS = [
+  'painotettavatoppiaineetlukiossa_a1',
+  'painotettavatoppiaineetlukiossa_a2',
+  'painotettavatoppiaineetlukiossa_b1',
+  'painotettavatoppiaineetlukiossa_b2',
+  'painotettavatoppiaineetlukiossa_b3',
+];

--- a/src/main/app/src/types/HakukohdeTypes.ts
+++ b/src/main/app/src/types/HakukohdeTypes.ts
@@ -75,6 +75,7 @@ export type Hakukohde = {
     linja?: Koodi;
     lisatietoa: Translateable;
     painotetutArvosanat: Array<PainotettuArvosana>;
+    painotetutArvosanatOppiaineittain: Array<PainotettuArvosana>;
   };
   hakulomakeAtaruId: string;
   hakulomakeKuvaus: Translateable;


### PR DESCRIPTION
Muutettu indeksointia niin, että myös avaamattomat "A1 kaikki" tyyppiset koodit päätyvät konfoon asti, ja voidaan näyttää helposti käyttäjälle. Lisäksi kaikki-koodit lisättävä koodistoon (lisätty hahtuvalle). Avattu lista löytyy nykyään kentästä painotetutArvosanatOppiaineittain, ja pistelaskuri päivitetty käyttämään tätä listaa painotetun keskiarvon laskemisessa. (voi olla ettei painotetun keskiarvon laskeminen toteutussivulla ole koskaan toiminutkaan noitten "A1 kaikki" ja vastaavien kanssa)