### PR TITLE
OY-4469 Add missing keyboard focus indicators

### DIFF
--- a/src/main/app/src/components/Pikalinkit.tsx
+++ b/src/main/app/src/components/Pikalinkit.tsx
@@ -89,6 +89,10 @@ const PikalinkitPaper = styled(Paper)({
   borderRadius: 0,
   padding: '20px 0',
   width: '100%',
+  [`.MuiLink-root.Mui-focusVisible`]: {
+    outline: '1px solid black',
+    outlineOffset: '2px',
+  },
 });
 
 export const Pikalinkit = ({

--- a/src/main/app/src/components/common/Footer.tsx
+++ b/src/main/app/src/components/common/Footer.tsx
@@ -62,6 +62,10 @@ const Root = styled('footer')({
     backgroundColor: colors.white,
     padding: '0 40px 0 40px',
   },
+  [`.MuiLink-root.Mui-focusVisible`]: {
+    outline: '1px solid black',
+    outlineOffset: '4px',
+  },
 });
 
 const overrides = {

--- a/src/main/app/src/components/common/Header.tsx
+++ b/src/main/app/src/components/common/Header.tsx
@@ -146,6 +146,12 @@ export const Header = ({
               </Box>
             </IconButton>
             <Link
+              sx={{
+                '&.Mui-focusVisible': {
+                  outline: '1px solid white',
+                  outlineOffset: '8px',
+                },
+              }}
               href="/"
               title={t('header.siirry-etusivulle')}
               onClick={refreshSideMenu}>
@@ -161,6 +167,11 @@ export const Header = ({
               <ToolbarLinkButton
                 href={urls.url('oma-opintopolku')}
                 startIcon={<MaterialIcon icon="apps" />}
+                sx={{
+                  '&.Mui-focusVisible': {
+                    outline: '1px solid white',
+                  },
+                }}
                 target="_blank">
                 {t('oma-opintopolku')}
               </ToolbarLinkButton>

--- a/src/main/app/src/components/common/Murupolku/index.jsx
+++ b/src/main/app/src/components/common/Murupolku/index.jsx
@@ -4,6 +4,7 @@ import { useTheme, useMediaQuery } from '@mui/material';
 import { head, last } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
+import { colors } from '#/src/colors';
 import { styled } from '#/src/theme';
 
 import { MurupolkuDrawer } from './MurupolkuDrawer';
@@ -37,6 +38,10 @@ const Root = styled('nav')(() => ({
     '&:last-child': {
       flex: '1 1 0%',
     },
+  },
+
+  [`.MuiLink-root.Mui-focusVisible`]: {
+    backgroundColor: colors.lighterGrey,
   },
 }));
 

--- a/src/main/app/src/components/common/SidebarValikko.tsx
+++ b/src/main/app/src/components/common/SidebarValikko.tsx
@@ -111,7 +111,7 @@ const SivuItem = ({
 
 const OtsikkoItem = ({ name }: { name: string }) => {
   return (
-    <h2 role="menuitem" className={classes.otsikkoText} tabIndex={0} aria-label={name}>
+    <h2 role="menuitem" className={classes.otsikkoText} tabIndex={-1} aria-label={name}>
       {name}
     </h2>
   );
@@ -131,7 +131,7 @@ const ValikkoItem = ({
       <ListItemText
         className={classes.valintaText}
         role="menuitem"
-        tabIndex={0}
+        tabIndex={-1}
         aria-label={name}>
         {name}
       </ListItemText>
@@ -170,7 +170,7 @@ export const SidebarValikko = (props: {
           <ListItemIcon className={classes.parentOtsikkoIconBase}>
             <MaterialIcon icon="chevron_left" className={classes.parentOtsikkoIcon} />
           </ListItemIcon>
-          <ListItemText role="menuitem" tabIndex={0} aria-label={parent.name}>
+          <ListItemText role="menuitem" tabIndex={-1} aria-label={parent.name}>
             {parent.name}
           </ListItemText>
         </ListItemLink>

--- a/src/main/app/src/components/kortti/Kortti.tsx
+++ b/src/main/app/src/components/kortti/Kortti.tsx
@@ -57,6 +57,10 @@ const StyledGrid = styled(Grid)({
   [`& .${classes.polku}`]: {
     background: colors.brandGreen,
   },
+  [`.MuiLink-root.Mui-focusVisible`]: {
+    outline: '1px solid white',
+    outlineOffset: '4px',
+  },
 });
 
 export const Kortti = ({ id }: { id: string }) => {

--- a/src/main/app/src/components/palaute/PalautePopup.jsx
+++ b/src/main/app/src/components/palaute/PalautePopup.jsx
@@ -80,6 +80,11 @@ export const PalautePopup = () => {
         ) : null}
 
         <Fab
+          sx={{
+            '&.Mui-focusVisible': {
+              outline: '2px solid black',
+            },
+          }}
           color="secondary"
           aria-label={t('palaute.anna-palautetta')}
           onClick={() => setShow(true)}

--- a/src/main/app/src/components/sivu/Sisalto.tsx
+++ b/src/main/app/src/components/sivu/Sisalto.tsx
@@ -6,6 +6,7 @@ import Markdown from 'markdown-to-jsx';
 import { EmbeddedPistelaskuri } from '#/src/components/laskuri/EmbeddedPistelaskuri';
 import { ImageComponent } from '#/src/components/sivu/ImageComponent';
 import { useContentful } from '#/src/hooks/useContentful';
+import { styled } from '#/src/theme';
 
 import { Accordion, Summary } from './Accordion';
 import { LinkOrYoutube } from './LinkOrYoutube';
@@ -14,6 +15,13 @@ import { EmbeddedHakutulosBox } from '../haku/EmbeddedHakutulosBox';
 const isBlank = (str?: string) => {
   return !str || /^\s*$/.test(str);
 };
+
+const StyledMarkdown = styled(Markdown)({
+  [`.MuiLink-root.Mui-focusVisible`]: {
+    outline: '1px solid black',
+    outlineOffset: '4px',
+  },
+});
 
 // Markdownissa tällainen:
 // <sivu slug="sivun-url-tunniste">Kuvaava linkin teksti</sivu>
@@ -40,7 +48,7 @@ export const Sisalto = ({
   rootRef?: RefObject<HTMLDivElement>;
 }) => {
   return content ? (
-    <Markdown
+    <StyledMarkdown
       options={{
         overrides: {
           img: {
@@ -106,6 +114,6 @@ export const Sisalto = ({
         },
       }}>
       {content}
-    </Markdown>
+    </StyledMarkdown>
   ) : null;
 };

--- a/src/main/app/src/components/sivu/TableOfContents.tsx
+++ b/src/main/app/src/components/sivu/TableOfContents.tsx
@@ -26,6 +26,9 @@ const StyledMarkdown = styled(Markdown)({
     borderLeftStyle: 'solid',
     display: 'block',
     paddingBottom: '15px',
+    [`&:focus-visible`]: {
+      outline: '1px solid black',
+    },
   },
 });
 


### PR DESCRIPTION
Visible keyboard focus indicators were missing from most (!) of the link type elements on the site. Fix at least the major ones that were easy to find and/or listed in the ticket.

MUI elements use `.Mui-focusVisible` dynamic class for determining keyboard focus, non-MUI elements must use `:focus-visible` CSS pseudoclass.