### PR TITLE
Oy 4471 Score graph and calculator accessibility issues

### DIFF
--- a/src/main/app/src/components/laskuri/KeskiarvoLaskuri.tsx
+++ b/src/main/app/src/components/laskuri/KeskiarvoLaskuri.tsx
@@ -116,7 +116,9 @@ export const KeskiarvoLaskuri = ({
   };
 
   return (
-    <LaskuriContainer embedded={embedded}>
+    <LaskuriContainer
+      embedded={embedded}
+      aria-label={t('pistelaskuri.keskiarvot-header')}>
       <Typography variant="h3" sx={{ fontSize: '1.25rem' }}>
         {t('pistelaskuri.keskiarvot-header')}
       </Typography>

--- a/src/main/app/src/components/laskuri/KeskiarvoModal.tsx
+++ b/src/main/app/src/components/laskuri/KeskiarvoModal.tsx
@@ -67,7 +67,8 @@ export const KeskiArvoModal = ({ open = false, closeFn, updateTulos, tulos }: Pr
       onClose={closeFn}
       maxWidth="lg"
       fullScreen={fullScreen}
-      scroll="body">
+      scroll="body"
+      aria-label={t('pistelaskuri.heading')}>
       <Box className={classes.container} ref={containerRef}>
         <Typography variant="h2">{t('pistelaskuri.heading')}</Typography>
         {tulos == null && (

--- a/src/main/app/src/components/laskuri/KeskiarvoTulos.tsx
+++ b/src/main/app/src/components/laskuri/KeskiarvoTulos.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { Box, Typography, Paper, useTheme, useMediaQuery } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import { useTranslation } from 'react-i18next';
 
 import { colors } from '#/src/colors';
@@ -181,7 +182,7 @@ export const KeskiarvoTulos = ({ tulos, embedded, kouluaineet, rootRef }: Props)
 
   return (
     <TulosContainer>
-      <Typography variant="h3" id="pistelaskuri__lukio__header" aria-hidden="true">
+      <Typography variant="h3" id="pistelaskuri__lukio__header">
         {t('pistelaskuri.lukio.header')}
       </Typography>
       {!isSmall && (
@@ -216,8 +217,15 @@ export const KeskiarvoTulos = ({ tulos, embedded, kouluaineet, rootRef }: Props)
           <LinkToValintaPerusteet />
         </Paper>
       </Box>
-      {isSmall && (
+      {isSmall ? (
         <Typography variant="h3" id="pistelaskuri__ammatillinen__header">
+          {t('pistelaskuri.ammatillinen.header')}
+        </Typography>
+      ) : (
+        <Typography
+          variant="h3"
+          id="pistelaskuri__ammatillinen__header"
+          style={visuallyHidden}>
           {t('pistelaskuri.ammatillinen.header')}
         </Typography>
       )}

--- a/src/main/app/src/components/laskuri/KeskiarvoTulos.tsx
+++ b/src/main/app/src/components/laskuri/KeskiarvoTulos.tsx
@@ -181,11 +181,18 @@ export const KeskiarvoTulos = ({ tulos, embedded, kouluaineet, rootRef }: Props)
 
   return (
     <TulosContainer>
-      <Typography variant="h3">{t('pistelaskuri.lukio.header')}</Typography>
+      <Typography variant="h3" id="pistelaskuri__lukio__header" aria-hidden="true">
+        {t('pistelaskuri.lukio.header')}
+      </Typography>
       {!isSmall && (
-        <Typography variant="h3">{t('pistelaskuri.ammatillinen.header')}</Typography>
+        <Typography
+          variant="h3"
+          id="pistelaskuri__ammatillinen__header"
+          aria-hidden="true">
+          {t('pistelaskuri.ammatillinen.header')}
+        </Typography>
       )}
-      <Box className={classes.column}>
+      <Box className={classes.column} aria-labelledby="pistelaskuri__lukio__header">
         {showPainokerroinSphere() ? (
           <ResultSpheresLukio
             keskiarvo={tulos.keskiarvo}
@@ -210,9 +217,13 @@ export const KeskiarvoTulos = ({ tulos, embedded, kouluaineet, rootRef }: Props)
         </Paper>
       </Box>
       {isSmall && (
-        <Typography variant="h3">{t('pistelaskuri.ammatillinen.header')}</Typography>
+        <Typography variant="h3" id="pistelaskuri__ammatillinen__header">
+          {t('pistelaskuri.ammatillinen.header')}
+        </Typography>
       )}
-      <Box className={classes.column}>
+      <Box
+        className={classes.column}
+        aria-labelledby="pistelaskuri__ammatillinen__header">
         {tulos.osalasku && (
           <>
             <ResultSpheresAmmatillinen osalasku={tulos.osalasku} embedded={embedded} />

--- a/src/main/app/src/components/laskuri/ResultSphere.tsx
+++ b/src/main/app/src/components/laskuri/ResultSphere.tsx
@@ -73,7 +73,10 @@ export const ResultSphere = ({
   const isMedium = (useMediaQuery(theme.breakpoints.down('md')) || embedded) && !isSmall;
 
   return (
-    <PalleroContainer className={classes.resultSphere}>
+    <PalleroContainer
+      className={classes.resultSphere}
+      aria-label={text + ' ' + resultWithComma}
+      role="figure">
       <VictoryPie
         width={isMedium ? 240 : 320}
         innerRadius={isMedium ? 85 : 95}

--- a/src/main/app/src/components/laskuri/ResultSphere.tsx
+++ b/src/main/app/src/components/laskuri/ResultSphere.tsx
@@ -73,12 +73,9 @@ export const ResultSphere = ({
   const isMedium = (useMediaQuery(theme.breakpoints.down('md')) || embedded) && !isSmall;
 
   return (
-    <PalleroContainer
-      className={classes.resultSphere}
-      aria-label={text + ' ' + resultWithComma}
-      role="figure">
+    <PalleroContainer className={classes.resultSphere} role="figure">
       <VictoryPie
-        aria-hidden={true}
+        aria-label={text + ' ' + resultWithComma}
         width={isMedium ? 240 : 320}
         innerRadius={isMedium ? 85 : 95}
         data={resultsData}

--- a/src/main/app/src/components/laskuri/ResultSphere.tsx
+++ b/src/main/app/src/components/laskuri/ResultSphere.tsx
@@ -78,6 +78,7 @@ export const ResultSphere = ({
       aria-label={text + ' ' + resultWithComma}
       role="figure">
       <VictoryPie
+        aria-hidden={true}
         width={isMedium ? 240 : 320}
         innerRadius={isMedium ? 85 : 95}
         data={resultsData}
@@ -97,7 +98,8 @@ export const ResultSphere = ({
       <Box
         className={
           embedded ? classes.embeddedResultTextContainer : classes.resultTextContainer
-        }>
+        }
+        aria-hidden={true}>
         <Typography sx={{ fontSize: '3rem', fontWeight: 'bold', marginBottom: '7px' }}>
           {resultWithComma}
         </Typography>

--- a/src/main/app/src/components/laskuri/aine/KieliSelect.tsx
+++ b/src/main/app/src/components/laskuri/aine/KieliSelect.tsx
@@ -91,6 +91,7 @@ export const KieliSelect = ({ aine, updateKieli }: Props) => {
       </InputLabel>
       {data !== undefined && (
         <Select
+          aria-label={t(aine.nimi) + ', ' + t('pistelaskuri.aine.kielennimi')}
           value={String(aine.kieliKoodi || null)}
           onChange={handleKieliChange}
           input={<Input className={classes.input} />}

--- a/src/main/app/src/components/laskuri/aine/KouluaineInput.tsx
+++ b/src/main/app/src/components/laskuri/aine/KouluaineInput.tsx
@@ -132,7 +132,10 @@ export const KouluaineInput = ({
   const isKieli = isKieliaine(kouluaine);
 
   return (
-    <AineContainer isKieli={isKieli} data-testid={`${PREFIX}${kouluaine.nimi}`}>
+    <AineContainer
+      isKieli={isKieli}
+      data-testid={`${PREFIX}${kouluaine.nimi}`}
+      aria-label={t(kouluaine.nimi)}>
       {isKieli && (
         <>
           <div className={classes.headerContainer}>
@@ -148,7 +151,8 @@ export const KouluaineInput = ({
       <Typography className={classes.gradeLabel}>
         {t(isKieli ? 'pistelaskuri.aine.arvosana' : kouluaine.nimi)}
       </Typography>
-      <ArvosanaContainer>
+      <ArvosanaContainer
+        aria-label={t(isKieli ? 'pistelaskuri.aine.arvosana' : kouluaine.nimi)}>
         <KouluaineSelect
           aine={kouluaine}
           updateArvosana={handleArvosanaChange}

--- a/src/main/app/src/components/laskuri/aine/KouluaineSelect.tsx
+++ b/src/main/app/src/components/laskuri/aine/KouluaineSelect.tsx
@@ -97,10 +97,12 @@ export const KouluaineSelect = ({
 
   return (
     <AineSelectControl
+      aria-label={t(aine.nimi)}
       isLisaKieli={isLisaKieli}
       variant="standard"
       sx={{ minWidth: 220 }}>
       <Select
+        aria-label={t(aine.nimi) + ' ' + t('pistelaskuri.aine.arvosana')}
         labelId={labelId}
         value={String(aine.arvosana)}
         onChange={handleArvosanaChange}

--- a/src/main/app/src/components/laskuri/aine/ValinnainenArvosana.tsx
+++ b/src/main/app/src/components/laskuri/aine/ValinnainenArvosana.tsx
@@ -110,6 +110,7 @@ export const ValinnainenArvosana = ({
         {t('pistelaskuri.aine.valinnaisaine')}
         <SelectContainer>
           <Select
+            autoFocus
             labelId={`${labelId}-${index}`}
             value={String(arvosana)}
             onChange={updateValinnainenArvosana}

--- a/src/main/app/src/components/laskuri/graafi/AccessibleGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/AccessibleGraafi.tsx
@@ -71,7 +71,12 @@ export const AccessibleGraafi = ({ hakukohde, tulos, isLukio }: Props) => {
   const { t } = useTranslation();
 
   return (
-    <Box sx={visuallyHidden}>
+    <Box
+      role="region"
+      aria-live="assertive"
+      aria-hidden={false}
+      sx={visuallyHidden}
+      id="graph__accessible__label">
       <Typography>
         {t('pistelaskuri.graafi.saavutettavuus.saate', {
           kohde: `${localize(hakukohde.nimi)} ${

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -183,6 +183,15 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos, hakukohdeOid }: Pr
             value={hakukohde}
             onChange={changeHakukohde}
             variant="standard"
+            aria-label={
+              t('pistelaskuri.graafi.heading') +
+              ', ' +
+              t(
+                isLukio
+                  ? 'pistelaskuri.graafi.hakukohde.lukio'
+                  : 'pistelaskuri.graafi.hakukohde.muu'
+              )
+            }
             disableUnderline={true}
             className={classes.hakukohdeSelect}
             input={<Input className={classes.hakukohdeInput} />}>
@@ -197,7 +206,7 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos, hakukohdeOid }: Pr
       )}
       {hakukohde?.metadata?.pistehistoria &&
         hakukohde?.metadata?.pistehistoria?.length > 0 && (
-          <Box>
+          <Box aria-live="polite">
             <PisteGraafi
               hakukohde={hakukohde}
               tulos={calculatedTulos}

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -183,15 +183,7 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos, hakukohdeOid }: Pr
             value={hakukohde}
             onChange={changeHakukohde}
             variant="standard"
-            aria-label={
-              t('pistelaskuri.graafi.heading') +
-              ', ' +
-              t(
-                isLukio
-                  ? 'pistelaskuri.graafi.hakukohde.lukio'
-                  : 'pistelaskuri.graafi.hakukohde.muu'
-              )
-            }
+            aria-labelledby="graph__accessible__label"
             disableUnderline={true}
             className={classes.hakukohdeSelect}
             input={<Input className={classes.hakukohdeInput} />}>
@@ -206,8 +198,9 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos, hakukohdeOid }: Pr
       )}
       {hakukohde?.metadata?.pistehistoria &&
         hakukohde?.metadata?.pistehistoria?.length > 0 && (
-          <Box aria-live="polite">
+          <Box>
             <PisteGraafi
+              aria-hidden={true}
               hakukohde={hakukohde}
               tulos={calculatedTulos}
               isLukio={isLukio}

--- a/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
+++ b/src/main/app/src/components/laskuri/graafi/GraafiContainer.tsx
@@ -200,7 +200,6 @@ export const GraafiContainer = ({ hakutiedot, isLukio, tulos, hakukohdeOid }: Pr
         hakukohde?.metadata?.pistehistoria?.length > 0 && (
           <Box>
             <PisteGraafi
-              aria-hidden={true}
               hakukohde={hakukohde}
               tulos={calculatedTulos}
               isLukio={isLukio}

--- a/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
@@ -84,8 +84,9 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
   };
 
   return (
-    <Box>
+    <Box role="figure" aria-labelledby="graph__accessible__label">
       <VictoryChart
+        aria-hidden={true}
         maxDomain={{
           y: maxY(data),
           x: GRAAFI_MAX_YEAR + graafiYearModifier(years, GraafiBoundary.MAX),
@@ -95,9 +96,9 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
           x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
         }}
         width={920}
-        aria-labelledby="graph__accessible__label"
         theme={VictoryTheme.material}>
         <VictoryAxis
+          aria-hidden={true}
           tickValues={years}
           style={{
             axis: { stroke: colors.invisible },
@@ -107,6 +108,7 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
           }}
         />
         <VictoryAxis
+          aria-hidden={true}
           dependentAxis
           tickValues={[4, 6, 8, maxY(data)]}
           style={{
@@ -118,6 +120,7 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
         />
         <VictoryGroup>
           <VictoryBar
+            aria-hidden={true}
             data={data}
             style={{
               data: { fill: ({ datum }) => getStyleByPistetyyppi(datum.pistetyyppi) },

--- a/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
+++ b/src/main/app/src/components/laskuri/graafi/PisteGraafi.tsx
@@ -40,6 +40,7 @@ const Lukiopistelaskelma = ({ tulos, years, ...props }: LukiopisteProps) => {
   return (
     <VictoryLine
       {...props}
+      aria-hidden={true}
       style={{
         data: { stroke: colors.sunglow, strokeWidth: 3 },
         labels: { fontSize: isSmall ? 32 : 16 },
@@ -55,7 +56,9 @@ const Lukiopistelaskelma = ({ tulos, years, ...props }: LukiopisteProps) => {
         },
       ]}
       labels={['', formatDouble(tulos.keskiarvoPainotettu)]}
-      labelComponent={<VictoryLabel renderInPortal dx={isSmall ? -25 : -15} />}
+      labelComponent={
+        <VictoryLabel renderInPortal dx={isSmall ? -25 : -15} aria-hidden={true} />
+      }
     />
   );
 };
@@ -81,7 +84,7 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
   };
 
   return (
-    <Box aria-hidden={true}>
+    <Box>
       <VictoryChart
         maxDomain={{
           y: maxY(data),
@@ -92,6 +95,7 @@ const PisteGraafiKouluarvosanat = ({ hakukohde, tulos }: Props) => {
           x: GRAAFI_MIN_YEAR + graafiYearModifier(years, GraafiBoundary.MIN),
         }}
         width={920}
+        aria-labelledby="graph__accessible__label"
         theme={VictoryTheme.material}>
         <VictoryAxis
           tickValues={years}


### PR DESCRIPTION
Fixes several keyboard navigation / screen reader labeling issues in score graph and score calculator popup - see original ticket. Mostly manually adding aria-labels and autoFocus triggers wherever they're needed.