### PR TITLE
OY-4399: Alatunnisteen saavutettavuuskorjaus

### DIFF
--- a/src/main/app/playwright/etusivu.spec.ts
+++ b/src/main/app/playwright/etusivu.spec.ts
@@ -52,10 +52,21 @@ test.describe('Etusivu', () => {
 
     await expect(page.getByRole('contentinfo')).toBeVisible();
 
+    const footer = page.getByRole('contentinfo');
+    await expect(
+      footer.getByRole('navigation', { name: 'Alatunnisteen valikko' })
+    ).toBeVisible();
+
+    const logoImages = footer.locator('img');
+    for (const img of await logoImages.all()) {
+      await expect(img).toHaveAttribute('alt', '');
+    }
+
     const results = await new AxeBuilder({ page })
       .withRules([
         'landmark-contentinfo-is-top-level',
         'landmark-no-duplicate-contentinfo',
+        'image-alt',
       ])
       .analyze();
     expect(results.violations).toEqual([]);

--- a/src/main/app/playwright/etusivu.spec.ts
+++ b/src/main/app/playwright/etusivu.spec.ts
@@ -1,3 +1,4 @@
+import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
 import {
@@ -42,6 +43,22 @@ test.describe('Etusivu', () => {
     await expect(page.getByAltText('Opintopolun logo')).toHaveCount(0);
     await expect(page.getByAltText('Opetushallituksen logo')).toHaveCount(0);
     await expect(page.locator('footer img[alt=""]')).toHaveCount(2);
+  });
+
+  test('Footer should have contentinfo landmark', async ({ page }) => {
+    await page.goto('/konfo/fi');
+    // eslint-disable-next-line playwright/no-networkidle
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('contentinfo')).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withRules([
+        'landmark-contentinfo-is-top-level',
+        'landmark-no-duplicate-contentinfo',
+      ])
+      .analyze();
+    expect(results.violations).toEqual([]);
   });
 
   test('Should pass koulutustyyppi filter selection to haku page', async ({ page }) => {

--- a/src/main/app/public/locales/fi/translation.json
+++ b/src/main/app/public/locales/fi/translation.json
@@ -114,7 +114,8 @@
     "palaute": "Anna palautetta",
     "oma-opintopolku": "Oma Opintopolku",
     "mikä-opintopolku": "Mikä on Opintopolku",
-    "tietoturvaseloste": "Tietoturvaseloste"
+    "tietoturvaseloste": "Tietoturvaseloste",
+    "valikko": "Alatunnisteen valikko"
   },
   "ei-loydy": {
     "404": "404",

--- a/src/main/app/src/App.tsx
+++ b/src/main/app/src/App.tsx
@@ -73,6 +73,30 @@ const MatomoTracker: React.FC = () => {
   return null;
 };
 
+const ContentColumn = styled('div')(
+  ({ isSmall, menuVisible }: { isSmall?: boolean; menuVisible?: boolean }) => ({
+    flexGrow: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    ...(menuVisible
+      ? {
+          transition: theme.transitions.create('margin', {
+            easing: theme.transitions.easing.easeOut,
+            duration: theme.transitions.duration.enteringScreen,
+          }),
+          marginLeft: isSmall ? 0 : SIDEMENU_WIDTH,
+        }
+      : {
+          transition: theme.transitions.create('margin', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+          }),
+          marginLeft: 0,
+        }),
+  })
+);
+
 const MainContent = styled('main')(
   ({ isSmall, menuVisible }: { isSmall?: boolean; menuVisible?: boolean }) => ({
     marginTop: getHeaderHeight(theme),
@@ -89,21 +113,6 @@ const MainContent = styled('main')(
           bottom: menuVisible ? 0 : 'auto',
         }
       : {}),
-    ...(menuVisible
-      ? {
-          transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.easeOut,
-            duration: theme.transitions.duration.enteringScreen,
-          }),
-          marginLeft: isSmall ? 0 : SIDEMENU_WIDTH,
-        }
-      : {
-          transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen,
-          }),
-          marginLeft: 0,
-        }),
   })
 );
 
@@ -277,17 +286,19 @@ export const App = () => {
           closeMenu={closeMenu}
           sideMenuKey={sideMenuKey}
         />
-        <MainContent id="app-main-content" isSmall={isSmall} menuVisible={menuVisible}>
-          <HeadingBoundary>
-            <MatomoTracker />
-            <KonfoRoutes />
+        <ContentColumn isSmall={isSmall} menuVisible={menuVisible}>
+          <MainContent id="app-main-content" isSmall={isSmall} menuVisible={menuVisible}>
             <HeadingBoundary>
-              <Notifications />
-              <Palvelut />
-              <Footer />
+              <MatomoTracker />
+              <KonfoRoutes />
+              <HeadingBoundary>
+                <Notifications />
+                <Palvelut />
+              </HeadingBoundary>
             </HeadingBoundary>
-          </HeadingBoundary>
-        </MainContent>
+          </MainContent>
+          <Footer />
+        </ContentColumn>
       </Box>
     </div>
   );

--- a/src/main/app/src/components/common/Footer.tsx
+++ b/src/main/app/src/components/common/Footer.tsx
@@ -2,6 +2,7 @@ import { Link, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Markdown from 'markdown-to-jsx';
+import { useTranslation } from 'react-i18next';
 
 import OPOLogoFooterFI from '#/src/assets/images/OpetushallitusIcon.svg';
 import OPHIconEN from '#/src/assets/images/OPH Logo EN.png';
@@ -99,6 +100,7 @@ const OPHFooterLogo = () => {
 };
 
 export const Footer = () => {
+  const { t } = useTranslation();
   const { data } = useContentful();
 
   // Footereita on vain yksi
@@ -115,28 +117,30 @@ export const Footer = () => {
             </Hr>
           </Grid>
         </Grid>
-        <Grid
-          container
-          direction="row"
-          justifyContent="space-evenly"
-          alignItems="flex-start"
-          paddingY={2}>
-          <Grid item xs={12} sm={4} md={3}>
-            <Box m={1}>
-              <Markdown options={overrides}>{content ?? ''}</Markdown>
-            </Box>
+        <nav aria-label={t('footer.valikko')}>
+          <Grid
+            container
+            direction="row"
+            justifyContent="space-evenly"
+            alignItems="flex-start"
+            paddingY={2}>
+            <Grid item xs={12} sm={4} md={3}>
+              <Box m={1}>
+                <Markdown options={overrides}>{content ?? ''}</Markdown>
+              </Box>
+            </Grid>
+            <Grid item xs={12} sm={4} md={3}>
+              <Box m={1}>
+                <Markdown options={overrides}>{contentCenter ?? ''}</Markdown>
+              </Box>
+            </Grid>
+            <Grid item xs={12} sm={4} md={3}>
+              <Box m={1}>
+                <Markdown options={overrides}>{contentRight ?? ''}</Markdown>
+              </Box>
+            </Grid>
           </Grid>
-          <Grid item xs={12} sm={4} md={3}>
-            <Box m={1}>
-              <Markdown options={overrides}>{contentCenter ?? ''}</Markdown>
-            </Box>
-          </Grid>
-          <Grid item xs={12} sm={4} md={3}>
-            <Box m={1}>
-              <Markdown options={overrides}>{contentRight ?? ''}</Markdown>
-            </Box>
-          </Grid>
-        </Grid>
+        </nav>
         <Grid container>
           <Grid item xs={12}>
             <Hr>


### PR DESCRIPTION
Alatunnisteelta puuttui ohjelmallinen merkintä (WCAG 2.1 SC 1.3.1, Taso A). Footer-elementti oli upotettu `<main>`-elementin sisään, jolloin HTML-spesifikaation mukaan `<footer>` menettää implisiittisen `contentinfo`-maamerkkinsä. Ruudunlukijat eivät voineet tunnistaa aluetta alatunnisteeksi.

## Ratkaisu

Lisätty `ContentColumn`-wrapper (`<div>`), joka ryhmittelee `<main>`- ja  `<footer>`-elementit. Wrapper hoitaa sivuvalikon aiheuttaman `marginLeft`-siirtymän, jolloin footer kapenee sisällön mukana valikon avautuessa. `<footer>` on nyt `<div>`-elementin sisällä (ei sektioiva elementti), joten se saa `contentinfo`-roolin automaattisesti.

## Testaus

Lisätty Playwright-testi (`etusivu.spec.ts`), joka varmistaa:
- `contentinfo`-maamerkin näkyvyyden (`getByRole('contentinfo')`)
- axe-säännöt `landmark-contentinfo-is-top-level` ja `landmark-no-duplicate-contentinfo`
