### PR TITLE
OY-5685: korjaa mobiilinäkymän alatunniste

### DIFF
--- a/src/main/app/playwright/etusivu.mobile.spec.ts
+++ b/src/main/app/playwright/etusivu.mobile.spec.ts
@@ -11,17 +11,15 @@ test.describe('Etusivu (mobiili)', () => {
 
   test('Footer should not overlap main content on mobile', async ({ page }) => {
     await page.goto('/konfo/fi');
-    // eslint-disable-next-line playwright/no-networkidle
-    await page.waitForLoadState('networkidle');
 
     const mainContent = page.locator('#app-main-content');
     const footer = page.getByRole('contentinfo');
 
+    await expect(mainContent).toBeVisible();
+    await expect(footer).toBeVisible();
+
     const mainBox = await mainContent.boundingBox();
     const footerBox = await footer.boundingBox();
-
-    expect(mainBox).not.toBeNull();
-    expect(footerBox).not.toBeNull();
 
     expect(footerBox!.y).toBeGreaterThanOrEqual(mainBox!.y + mainBox!.height);
   });

--- a/src/main/app/playwright/etusivu.mobile.spec.ts
+++ b/src/main/app/playwright/etusivu.mobile.spec.ts
@@ -1,0 +1,28 @@
+import { devices, expect, test } from '@playwright/test';
+
+import { setupCommonTest } from './test-tools';
+
+test.use({ ...devices['Galaxy S9+'] });
+
+test.describe('Etusivu (mobiili)', () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await setupCommonTest({ page, context, baseURL });
+  });
+
+  test('Footer should not overlap main content on mobile', async ({ page }) => {
+    await page.goto('/konfo/fi');
+    // eslint-disable-next-line playwright/no-networkidle
+    await page.waitForLoadState('networkidle');
+
+    const mainContent = page.locator('#app-main-content');
+    const footer = page.getByRole('contentinfo');
+
+    const mainBox = await mainContent.boundingBox();
+    const footerBox = await footer.boundingBox();
+
+    expect(mainBox).not.toBeNull();
+    expect(footerBox).not.toBeNull();
+
+    expect(footerBox!.y).toBeGreaterThanOrEqual(mainBox!.y + mainBox!.height);
+  });
+});

--- a/src/main/app/src/App.tsx
+++ b/src/main/app/src/App.tsx
@@ -266,6 +266,17 @@ export const App = () => {
     }
   }, [isFetching, isAtEtusivu, titleObj, language, pathname]);
 
+  useEffect(() => {
+    if (isSmall && menuVisible) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isSmall, menuVisible]);
+
   // Tämä alustaa Elisan chatin käyttöön
   useChat();
 

--- a/src/main/app/src/App.tsx
+++ b/src/main/app/src/App.tsx
@@ -79,7 +79,7 @@ const ContentColumn = styled('div')(
     minWidth: 0,
     display: 'flex',
     flexDirection: 'column',
-    ...(isSmall ? { overflowX: 'hidden' } : {}),
+    ...(isSmall ? { overflowX: 'clip' } : {}),
     ...(menuVisible
       ? {
           transition: theme.transitions.create('margin', {

--- a/src/main/app/src/App.tsx
+++ b/src/main/app/src/App.tsx
@@ -79,6 +79,7 @@ const ContentColumn = styled('div')(
     minWidth: 0,
     display: 'flex',
     flexDirection: 'column',
+    ...(isSmall ? { overflowX: 'hidden' } : {}),
     ...(menuVisible
       ? {
           transition: theme.transitions.create('margin', {

--- a/src/main/app/src/App.tsx
+++ b/src/main/app/src/App.tsx
@@ -103,14 +103,14 @@ const MainContent = styled('main')(
     minWidth: 0,
     flexGrow: 1,
     padding: 0,
-    ...(isSmall
+    ...(isSmall && menuVisible
       ? {
           position: 'absolute',
           left: 0,
           right: 0,
           overflow: 'hidden',
-          top: menuVisible ? 0 : 'auto',
-          bottom: menuVisible ? 0 : 'auto',
+          top: 0,
+          bottom: 0,
         }
       : {}),
   })

--- a/src/main/app/src/App.tsx
+++ b/src/main/app/src/App.tsx
@@ -272,9 +272,6 @@ export const App = () => {
     } else {
       document.body.style.overflow = '';
     }
-    return () => {
-      document.body.style.overflow = '';
-    };
   }, [isSmall, menuVisible]);
 
   // Tämä alustaa Elisan chatin käyttöön


### PR DESCRIPTION
## Ongelma

OY-4399:n alatunnisteen saavutettavuuskorjauksen yhteydessä `<Footer>`-komponentti siirrettiin semanttisesti oikein `<main>`-elementin ulkopuolelle `ContentColumn`-diviin. Mobiilinäkymässä tämä aiheutti kolme ongelmaa:

1. **Footer siirtyi sisällön päälle** — `MainContent` sai aina `position: absolute` mobiilissa, jolloin se poistui flex-virrasta ja footer renderöityi sisällön päälle.
2. **Leveä sisältö vuoti vaakasuunnassa** — `overflow: hidden` oli `MainContent`-tasolla eikä se enää kattanut koko sisältöaluetta.
3. **Valikon sulkunappi katosi scrollatessa** — `StyledAppBar` on mobiilissa `position: absolute` (ei fixed), joten sulkunappi scrollasi pois näkyvistä kun sivuvalikon takana oleva sivu oli vielä scrollattavissa.

## Ratkaisu

**`MainContent` (App.tsx):** `position: absolute` asetetaan nyt vain kun sivuvalikko on auki mobiililla (`isSmall && menuVisible`). Kun valikko on kiinni, `MainContent` pysyy normaalissa flex-virrassa ja footer asettuu sen alle oikein.

**`ContentColumn` (App.tsx):** Lisätty `overflowX: 'clip'` mobiililla. Tämä leikkaa vaakasuuntaisen ylivuodon kuten `hidden`, mutta ei luo uutta scroll-kontekstia — joten `position: sticky` toimii edelleen jälkeläisillä (mm. `TableOfContents` ja `Sisallysluettelo`). `overflow: hidden` olisi rikkonut nämä sticky-elementit mobiilissa.

**Body scroll -lukitus (App.tsx):** Lisätty `useEffect` joka asettaa `document.body.style.overflow = 'hidden'` kun mobiilivalikko on auki. Tämä estää sivun scrollaamisen valikon takana ja pitää sulkunapin näkyvissä.

## Testit

Lisätty `etusivu.mobile.spec.ts` (Galaxy S9+ -viewport), joka varmistaa että footerin `y`-koordinaatti on vähintään yhtä suuri kuin pääsisällön alareunan `y`-koordinaatti. Testi odottaa molempien elementtien näkyvyyttä `toBeVisible()`-kutsuilla ennen geometriatarkistusta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)