### PR TITLE
OY-5559: Hakusanan synkkaus haun ja rajainmuutosten välillä

### DIFF
--- a/src/main/app/playwright/etusivu.spec.ts
+++ b/src/main/app/playwright/etusivu.spec.ts
@@ -98,4 +98,29 @@ test.describe('Etusivu', () => {
       '/konfo/fi/haku/auto?koulutustyyppi=lk&order=desc&size=20&sort=score'
     );
   });
+
+  test('Search keyword stays in the search field after searching from front page', async ({
+    page,
+  }) => {
+    await page.route(
+      '/konfo-backend/search/oppilaitokset**',
+      fixtureFromFile('search-oppilaitokset-all.json')
+    );
+
+    await page.route(
+      '/konfo-backend/search/koulutukset**',
+      fixtureFromFile('search-koulutukset-auto.json')
+    );
+
+    await page.goto('/konfo');
+    await getSearchInput(page).fill('ajoneuvo');
+    await getSearchButton(page).click();
+
+    await expectURLEndsWith(
+      page,
+      '/konfo/fi/haku/ajoneuvo?order=desc&size=20&sort=score'
+    );
+    await expect(page.getByRole('progressbar').last()).toBeHidden();
+    await expect(getSearchInput(page)).toHaveValue('ajoneuvo');
+  });
 });

--- a/src/main/app/playwright/haku.spec.ts
+++ b/src/main/app/playwright/haku.spec.ts
@@ -223,6 +223,92 @@ test.describe('Haku', () => {
     await expect(hakuKaynnissaChk).not.toBeChecked();
   });
 
+  test('Search keyword from URL is shown in the search field', async ({ page }) => {
+    await page.route(
+      '/konfo-backend/search/koulutukset**',
+      fixtureFromFile('search-koulutukset-auto.json')
+    );
+    await page.goto('/konfo/fi/haku/ajoneuvo?order=desc&size=20&sort=score');
+    await expect(page.getByRole('progressbar').last()).toBeHidden();
+
+    await expect(getSearchInput(page)).toHaveValue('ajoneuvo');
+  });
+
+  test('Cleared search keyword is not sent when changing filters', async ({ page }) => {
+    await page.route(
+      '/konfo-backend/search/koulutukset**',
+      fixtureFromFile('search-koulutukset-auto.json')
+    );
+    await page.goto('/konfo/fi/haku');
+
+    const searchInput = getSearchInput(page);
+    await searchInput.fill('auto');
+    await getSearchButton(page).click();
+    await expectURLEndsWith(page, '/konfo/fi/haku/auto?order=desc&size=20&sort=score');
+
+    await searchInput.fill('');
+
+    const requestPromiseForFilterWithoutKeyword = page.waitForRequest(
+      (request) => {
+        const requestUrl = new URL(request.url());
+        return (
+          requestUrl.pathname === '/konfo-backend/search/koulutukset' &&
+          requestUrl.searchParams.get('hakukaynnissa') === 'true' &&
+          !requestUrl.searchParams.has('keyword') &&
+          request.method() === 'GET'
+        );
+      },
+      { timeout: 5000 }
+    );
+
+    const hakukaynnissaFilter = page.getByTestId('hakukaynnissa-filter');
+    const hakuKaynnissaChk = hakukaynnissaFilter.locator(
+      'input[type="checkbox"][aria-labelledby="filter-list-label-hakukaynnissa"]'
+    );
+    await hakuKaynnissaChk.click();
+
+    await requestPromiseForFilterWithoutKeyword;
+    await expectURLEndsWith(
+      page,
+      '/konfo/fi/haku?hakukaynnissa=true&order=desc&size=20&sort=score'
+    );
+  });
+
+  test('Editing search keyword does not update search results before search or filter change', async ({
+    page,
+  }) => {
+    await page.route(
+      '/konfo-backend/search/koulutukset**',
+      fixtureFromFile('search-koulutukset-auto.json')
+    );
+    await page.goto('/konfo/fi/haku');
+
+    const searchInput = getSearchInput(page);
+    await searchInput.fill('auto');
+    await getSearchButton(page).click();
+    await expectURLEndsWith(page, '/konfo/fi/haku/auto?order=desc&size=20&sort=score');
+
+    const requestPromiseForEditedKeyword = page
+      .waitForRequest(
+        (request) => {
+          const requestUrl = new URL(request.url());
+          return (
+            requestUrl.pathname === '/konfo-backend/search/koulutukset' &&
+            requestUrl.searchParams.get('keyword') === 'ajoneuvo' &&
+            request.method() === 'GET'
+          );
+        },
+        { timeout: 1000 }
+      )
+      .then(() => true)
+      .catch(() => false);
+
+    await searchInput.fill('ajoneuvo');
+
+    await expect(requestPromiseForEditedKeyword).resolves.toBe(false);
+    await expectURLEndsWith(page, '/konfo/fi/haku/auto?order=desc&size=20&sort=score');
+  });
+
   test('Hakutapa filter checkboxes', async ({ page }) => {
     await page.route(
       '/konfo-backend/search/koulutukset**',

--- a/src/main/app/src/components/Etusivu.tsx
+++ b/src/main/app/src/components/Etusivu.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 import { Box, Button, Grid, Paper } from '@mui/material';
 import { isEmpty, size, sortBy, take } from 'lodash';
 import Markdown from 'markdown-to-jsx';
 import { useTranslation } from 'react-i18next';
-import { useEffectOnce } from 'react-use';
 
 import { colors } from '#/src/colors';
 import { LoadingCircle } from '#/src/components/common/LoadingCircle';
@@ -59,11 +58,11 @@ export const Etusivu = () => {
     }
   }, [isLoading, uutislinkit]);
 
-  useEffectOnce(() => {
+  useLayoutEffect(() => {
     // NOTE: Tyhjätään aina kaikki hakutulosvalinnat kun saavutaan etusivulle
     setKeyword('');
     clearRajainValues();
-  });
+  }, [setKeyword, clearRajainValues]);
   const pikalinkitData = getOne(pikalinkit);
 
   const pageSectionGap = usePageSectionGap();

--- a/src/main/app/src/components/haku/HakuPage.tsx
+++ b/src/main/app/src/components/haku/HakuPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 
 import {
   Box,
@@ -139,7 +139,7 @@ const useSyncedHakuParams = () => {
   const dispatch = useDispatch();
 
   // Kun URL:n search-parametrit muuttuu, synkataan muutokset reduxiin
-  useEffect(() => {
+  useLayoutEffect(() => {
     dispatch(urlParamsChanged({ keyword, search }));
   }, [dispatch, search, keyword]);
 };

--- a/src/main/app/src/components/haku/Hakupalkki.tsx
+++ b/src/main/app/src/components/haku/Hakupalkki.tsx
@@ -1,6 +1,11 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useLayoutEffect } from 'react';
 
 import { Box } from '@mui/material';
+import { useDispatch } from 'react-redux';
+import { useLocation, useParams } from 'react-router-dom';
+
+import { syncKeywordFromUrl } from '#/src/store/reducers/hakutulosSlice';
+import { getLanguage } from '#/src/tools/localization';
 
 import { useSearch } from './hakutulosHooks';
 import { SearchBox } from './SearchBox';
@@ -10,7 +15,17 @@ export const Hakupalkki = ({
 }: {
   rajaaButton?: React.JSX.Element | null;
 }) => {
-  const { keyword, goToSearchPage, setKeyword } = useSearch();
+  const { draftKeyword, goToSearchPage, setKeyword, setDraftKeyword } = useSearch();
+  const { keyword: urlKeyword } = useParams();
+  const { pathname } = useLocation();
+  const dispatch = useDispatch();
+  const isHakuPage = pathname.startsWith(`/${getLanguage()}/haku`);
+
+  useLayoutEffect(() => {
+    if (isHakuPage) {
+      dispatch(syncKeywordFromUrl({ keyword: urlKeyword ?? '' }));
+    }
+  }, [dispatch, isHakuPage, urlKeyword]);
 
   const doSearch = useCallback(
     (phrase: string) => {
@@ -23,9 +38,9 @@ export const Hakupalkki = ({
   return (
     <Box marginBottom={1}>
       <SearchBox
-        key={keyword}
-        keyword={keyword}
+        draftKeyword={draftKeyword}
         doSearch={doSearch}
+        setDraftKeyword={setDraftKeyword}
         rajaaButton={rajaaButton}
       />
     </Box>

--- a/src/main/app/src/components/haku/SearchBox.tsx
+++ b/src/main/app/src/components/haku/SearchBox.tsx
@@ -140,31 +140,32 @@ const createRenderAutocompleteGroup = (t: TFunction) => {
 };
 
 export const SearchBox = ({
-  keyword,
+  draftKeyword,
   doSearch,
+  setDraftKeyword,
   rajaaButton,
 }: {
-  keyword: string;
+  draftKeyword: string;
   doSearch: (keyword: string) => void;
+  setDraftKeyword: (keyword: string) => void;
   rajaaButton?: React.JSX.Element | null;
 }) => {
   const { setSearchPhraseDebounced, isFetching, data } = useAutoComplete();
 
-  const [inputValue, setInputValue] = useState<string>(() => keyword || '');
   const [highlightedLabel, setHighlightedLabel] = useState('');
   const [highlightedLink, setHighlightedLink] = useState<string | null>(null);
-  const isKeywordValid = checkIsKeywordValid(inputValue);
+  const isKeywordValid = checkIsKeywordValid(draftKeyword);
 
   const { t } = useTranslation();
 
   const koulutusOptions = useAutocompleteOptions(
-    inputValue,
+    draftKeyword,
     'koulutus',
     t,
     data?.koulutukset
   );
   const oppilaitosOptions = useAutocompleteOptions(
-    inputValue,
+    draftKeyword,
     'oppilaitos',
     t,
     data?.oppilaitokset
@@ -243,8 +244,7 @@ export const SearchBox = ({
         <Autocomplete
           fullWidth={true}
           disablePortal={true}
-          key={keyword}
-          inputValue={inputValue}
+          inputValue={draftKeyword}
           freeSolo={true}
           options={allHits}
           filterOptions={identity}
@@ -275,7 +275,7 @@ export const SearchBox = ({
           }}
           onInputChange={(_e, newInputValue, reason) => {
             if (reason !== 'reset') {
-              setInputValue(newInputValue);
+              setDraftKeyword(newInputValue);
               setSearchPhraseDebounced(newInputValue);
             }
           }}

--- a/src/main/app/src/components/haku/hakutulosHooks.ts
+++ b/src/main/app/src/components/haku/hakutulosHooks.ts
@@ -45,12 +45,14 @@ import {
   setOrder,
   clearRajainValues as clearReduxRajainValues,
   setKeyword,
+  setDraftKeyword,
   RajainValues,
 } from '#/src/store/reducers/hakutulosSlice';
 import {
   getRajainValues,
   getIsAnyFilterSelected,
   getKeyword,
+  getDraftKeyword,
   getKoulutusOffset,
   getKoulutusPage,
   getOppilaitosOffset,
@@ -153,6 +155,7 @@ export const useSearch = () => {
 
   const requestParams = useSelector(getSearchRequestParams);
   const { keyword } = requestParams;
+  const draftKeyword = useSelector(getDraftKeyword);
 
   const koulutusPage = useSelector(getKoulutusPage);
   const oppilaitosPage = useSelector(getOppilaitosPage);
@@ -261,6 +264,11 @@ export const useSearch = () => {
     [dispatch]
   );
 
+  const setDraftKeywordCb = useCallback(
+    (k: string) => dispatch(setDraftKeyword({ keyword: k })),
+    [dispatch]
+  );
+
   const setRajainValues = useCallback(
     (changes: any) => {
       dispatch(setReduxRajainValues(changes));
@@ -278,7 +286,9 @@ export const useSearch = () => {
 
   return {
     keyword,
+    draftKeyword,
     setKeyword: setKeywordCb,
+    setDraftKeyword: setDraftKeywordCb,
     isFetching,
     isAnyRajainSelected,
     status,

--- a/src/main/app/src/store/reducers/hakutulosSlice.ts
+++ b/src/main/app/src/store/reducers/hakutulosSlice.ts
@@ -104,6 +104,8 @@ export type HakutulosSlice = {
   koulutusOffset: number;
   oppilaitosOffset: number;
   keyword: string;
+  draftKeyword: string;
+  isDraftKeywordModified: boolean;
 } & RajainValues;
 
 export const HAKUTULOS_INITIAL: HakutulosSlice = {
@@ -119,6 +121,8 @@ export const HAKUTULOS_INITIAL: HakutulosSlice = {
 
   // Persistoidut suodatinvalinnat
   keyword: '',
+  draftKeyword: '',
+  isDraftKeywordModified: false,
   ...HAKU_RAJAIMET_INITIAL,
 };
 
@@ -141,7 +145,21 @@ export const hakutulosSlice = createSlice({
   reducers: {
     setKeyword: (state, { payload }: PayloadAction<{ keyword: string }>) => {
       state.keyword = payload.keyword;
+      state.draftKeyword = payload.keyword;
+      state.isDraftKeywordModified = false;
       resetOffset(state);
+    },
+    setDraftKeyword: (state, { payload }: PayloadAction<{ keyword: string }>) => {
+      state.draftKeyword = payload.keyword;
+      state.isDraftKeywordModified = state.keyword !== payload.keyword;
+    },
+    syncKeywordFromUrl: (state, { payload }: PayloadAction<{ keyword: string }>) => {
+      const keywordChanged = state.keyword !== payload.keyword;
+      state.keyword = payload.keyword;
+      if (keywordChanged || !state.isDraftKeywordModified) {
+        state.draftKeyword = payload.keyword;
+        state.isDraftKeywordModified = false;
+      }
     },
     setSelectedTab: (
       state,
@@ -153,6 +171,8 @@ export const hakutulosSlice = createSlice({
       state,
       { payload: newValues }: PayloadAction<Partial<RajainValues>>
     ) => {
+      state.keyword = state.draftKeyword;
+      state.isDraftKeywordModified = false;
       Object.assign(
         state,
         mapValues(newValues, (v) => (Array.isArray(v) ? sortArray(v) : v))
@@ -163,6 +183,8 @@ export const hakutulosSlice = createSlice({
       resetOffset(state);
     },
     clearRajainValues: (state) => {
+      state.keyword = state.draftKeyword;
+      state.isDraftKeywordModified = false;
       Object.assign(state, HAKU_RAJAIMET_INITIAL);
       resetOffset(state);
     },
@@ -197,7 +219,17 @@ export const hakutulosSlice = createSlice({
       forEach(params, (value, key) => {
         match(key)
           .with('keyword', 'size', 'order', 'sort', () => {
-            Object.assign(state, { [key]: value });
+            if (key === 'keyword') {
+              const keywordValue = value ?? '';
+              const keywordChanged = state.keyword !== keywordValue;
+              state.keyword = keywordValue;
+              if (keywordChanged || !state.isDraftKeywordModified) {
+                state.draftKeyword = keywordValue;
+                state.isDraftKeywordModified = false;
+              }
+            } else {
+              Object.assign(state, { [key]: value ?? '' });
+            }
           })
           .with(RAJAIN_TYPES.SIJAINTI, () => {
             const valueList = getParamValueList(value);
@@ -258,6 +290,8 @@ export const hakutulosSlice = createSlice({
 
 export const {
   setKeyword,
+  setDraftKeyword,
+  syncKeywordFromUrl,
   setSelectedTab,
   setRajainValues,
   resetPagination,

--- a/src/main/app/src/store/reducers/hakutulosSliceSelector.ts
+++ b/src/main/app/src/store/reducers/hakutulosSliceSelector.ts
@@ -13,6 +13,8 @@ import {
 // State data getters
 export const getKeyword = (state: RootState) => state.hakutulos.keyword;
 
+export const getDraftKeyword = (state: RootState) => state.hakutulos.draftKeyword;
+
 export const getKoulutusOffset = (state: RootState) => state.hakutulos.koulutusOffset;
 
 export const getOppilaitosOffset = (state: RootState) => state.hakutulos.oppilaitosOffset;


### PR DESCRIPTION
- Erottaa hakukentän luonnosarvon varsinaisesta haun keyword-arvosta
- Säilyttää hakusanan hakukentässä haun jälkeen
- Päivittää hakusanan rajainmuutoksen yhteydessä kentän nykyisen arvon mukaan
- Estää tyhjennetyn hakusanan jäämisen backend-pyyntöihin ja URLiin
- Lisää regressiotestit etusivun haulle, URLista avattavalle haulle ja rajainmuutoksille